### PR TITLE
Worker class and tools

### DIFF
--- a/easyvvuq/__init__.py
+++ b/easyvvuq/__init__.py
@@ -3,6 +3,7 @@ from .constants import OutputType
 from . import data_structs
 from .params_specification import ParamsSpecification
 from .campaign import Campaign
+from .worker import Worker
 from . import actions
 from . import distributions
 from . import encoders

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -646,7 +646,7 @@ class Campaign:
         # Loop through all runs in this campaign with the specified status,
         # and call the specified user function for each.
         for run_id, run_data in self.campaign_db.runs(status=status):
-            fn(run_data['run_dir'], run_data['params'])
+            fn(run_id, run_data)
 
     def apply_for_each_run_dir(self, action):
         """

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -612,25 +612,20 @@ class Campaign:
             fixtures = self._active_app['fixtures']
 
         # Loop through all runs with status NEW
-        runs_dir = self.campaign_db.runs_dir()
         for run_id, run_data in self.campaign_db.runs(status=Status.NEW):
 
-            # Make run directory
-            target_dir = os.path.join(runs_dir, run_id)
-            os.makedirs(target_dir)
+            # Make directory for this run's output
+            os.makedirs(run_data['run_dir'])
 
-            # TODO: Check that this isn't insanely inefficient (almost
-            #  certainly will be hammering the database for large run lists)
-            self.campaign_db.set_dir_for_run(run_id, target_dir)
-
+            # Encode run
             if active_encoder is not None:
                 if use_fixtures:
                     active_encoder.encode(params=run_data['params'],
                                           fixtures=fixtures,
-                                          target_dir=target_dir)
+                                          target_dir=run_data['run_dir'])
                 else:
                     active_encoder.encode(params=run_data['params'],
-                                          target_dir=target_dir)
+                                          target_dir=run_data['run_dir'])
 
             # Update run status in db
             self.campaign_db.set_run_statuses([run_id], Status.ENCODED)

--- a/easyvvuq/data_structs.py
+++ b/easyvvuq/data_structs.py
@@ -127,7 +127,7 @@ class RunInfo:
     status : enum(Status)
     """
 
-    def __init__(self, run_name='', ensemble_name='', app=None, params=None, sample=None,
+    def __init__(self, run_name=None, ensemble_name=None, run_dir=None, app=None, params=None, sample=None,
                  campaign=None, status=constants.Status.NEW):
 
         # TODO: Handle fixtures
@@ -141,6 +141,7 @@ class RunInfo:
         self.app = app
         self.run_name = run_name
         self.ensemble_name = ensemble_name
+        self.run_dir = run_dir
 
         if not params:
             message = f'No run configuration specified for run {run_name}'
@@ -171,6 +172,7 @@ class RunInfo:
             out_dict = {
                 'run_name': self.run_name,
                 'ensemble_name': self.ensemble_name,
+                'run_dir': self.run_dir,
                 'params': json.dumps(self.params),
                 'status': constants.Status(self.status),
                 'campaign': self.campaign,
@@ -183,6 +185,7 @@ class RunInfo:
             out_dict = {
                 'run_name': self.run_name,
                 'ensemble_name': self.ensemble_name,
+                'run_dir': self.run_dir,
                 'params': self.params,
                 'status': constants.Status(self.status),
                 'campaign': self.campaign,

--- a/easyvvuq/data_structs.py
+++ b/easyvvuq/data_structs.py
@@ -127,8 +127,16 @@ class RunInfo:
     status : enum(Status)
     """
 
-    def __init__(self, run_name=None, ensemble_name=None, run_dir=None, app=None, params=None, sample=None,
-                 campaign=None, status=constants.Status.NEW):
+    def __init__(
+            self,
+            run_name=None,
+            ensemble_name=None,
+            run_dir=None,
+            app=None,
+            params=None,
+            sample=None,
+            campaign=None,
+            status=constants.Status.NEW):
 
         # TODO: Handle fixtures
 

--- a/easyvvuq/db/json.py
+++ b/easyvvuq/db/json.py
@@ -352,6 +352,7 @@ class CampaignDB(BaseCampaignDB):
             this_run = run_info.to_dict()
             this_run['run_name'] = name
             this_run['ensemble_name'] = ensemble
+            this_run['run_dir'] = os.path.join(self._campaign_info['runs_dir'], name)
 
             self._runs[name] = this_run
             self._next_run += 1

--- a/easyvvuq/db/sql.py
+++ b/easyvvuq/db/sql.py
@@ -1,5 +1,6 @@
 """Provides class that allows access to an SQL format CampaignDB.
 """
+import os
 import json
 import logging
 import pandas as pd
@@ -368,9 +369,11 @@ class CampaignDB(BaseCampaignDB):
         """
 
         # Add all runs to RunTable
+        runs_dir = self.runs_dir()
         for run_info in run_info_list:
             run_info.ensemble_name = f"{ensemble_prefix}{self._next_ensemble}"
             run_info.run_name = f"{run_prefix}{self._next_run}"
+            run_info.run_dir = os.path.join(runs_dir, run_info.run_name)
 
             run = RunTable(**run_info.to_dict(flatten=True))
             self.session.add(run)

--- a/easyvvuq/tools/external_encoder.py
+++ b/easyvvuq/tools/external_encoder.py
@@ -1,0 +1,32 @@
+import os, sys
+import logging
+
+import easyvvuq as uq
+
+__copyright__ = """
+
+    Copyright 2018 Robin A. Richardson, David W. Wright
+
+    This file is part of EasyVVUQ
+
+    EasyVVUQ is free software: you can redistribute it and/or modify
+    it under the terms of the Lesser GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    EasyVVUQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    Lesser GNU General Public License for more details.
+
+    You should have received a copy of the Lesser GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+__license__ = "LGPL"
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit("Usage: python3 external_encoder.py run_ID_list.txt")
+
+    

--- a/easyvvuq/tools/external_encoder.py
+++ b/easyvvuq/tools/external_encoder.py
@@ -1,7 +1,4 @@
-import os
 import sys
-import logging
-
 import easyvvuq as uq
 
 __copyright__ = """

--- a/easyvvuq/tools/external_encoder.py
+++ b/easyvvuq/tools/external_encoder.py
@@ -29,7 +29,9 @@ __license__ = "LGPL"
 if __name__ == "__main__":
     if len(sys.argv) != 6:
         sys.exit(
-            "Usage: python3 external_encoder.py db_type db_location campaign_name app_name comma_separated_run_id_list")
+            f("Usage: python3 external_encoder.py db_type db_location"
+              "campaign_name app_name comma_separated_run_id_list")
+        )
 
     db_type = sys.argv[1]
     db_location = sys.argv[2]

--- a/easyvvuq/tools/external_encoder.py
+++ b/easyvvuq/tools/external_encoder.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 import logging
 
 import easyvvuq as uq
@@ -27,7 +28,8 @@ __license__ = "LGPL"
 
 if __name__ == "__main__":
     if len(sys.argv) != 6:
-        sys.exit("Usage: python3 external_encoder.py db_type db_location campaign_name app_name comma_separated_run_id_list")
+        sys.exit(
+            "Usage: python3 external_encoder.py db_type db_location campaign_name app_name comma_separated_run_id_list")
 
     db_type = sys.argv[1]
     db_location = sys.argv[2]
@@ -36,9 +38,9 @@ if __name__ == "__main__":
     run_id_list = sys.argv[5].split(',')
 
     worker = uq.Worker(
-                    db_type=db_type,
-                    db_location=db_location,
-                    campaign_name=campaign_name,
-                    app_name=app_name)
+        db_type=db_type,
+        db_location=db_location,
+        campaign_name=campaign_name,
+        app_name=app_name)
 
     worker.encode_runs(run_id_list)

--- a/easyvvuq/tools/external_encoder.py
+++ b/easyvvuq/tools/external_encoder.py
@@ -26,7 +26,19 @@ __copyright__ = """
 __license__ = "LGPL"
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        sys.exit("Usage: python3 external_encoder.py run_ID_list.txt")
+    if len(sys.argv) != 6:
+        sys.exit("Usage: python3 external_encoder.py db_type db_location campaign_name app_name comma_separated_run_id_list")
+
+    db_type = sys.argv[1]
+    db_location = sys.argv[2]
+    campaign_name = sys.argv[3]
+    app_name = sys.argv[4]
+    run_id_list = sys.argv[5].split(',')
+
+    worker = uq.Worker(
+                    db_type=db_type,
+                    db_location=db_location,
+                    campaign_name=campaign_name,
+                    app_name=app_name)
 
     

--- a/easyvvuq/tools/external_encoder.py
+++ b/easyvvuq/tools/external_encoder.py
@@ -41,4 +41,4 @@ if __name__ == "__main__":
                     campaign_name=campaign_name,
                     app_name=app_name)
 
-    
+    worker.encode_runs(run_id_list)

--- a/easyvvuq/worker.py
+++ b/easyvvuq/worker.py
@@ -69,7 +69,7 @@ class Worker:
         (self._active_app_encoder,
          self._active_app_decoder) = self.campaign_db.resurrect_app(app_name)
 
-    def encode_run(self, run_id_list):
+    def encode_runs(self, run_id_list):
 
         # Get the encoder for this app. If none is set, only the directory structure
         # will be created.
@@ -101,7 +101,7 @@ class Worker:
                                           target_dir=target_dir)
 
         # Update run statuses in db
-        self.campaign_db.set_run_statuses([run_id_list], Status.ENCODED)
+        self.campaign_db.set_run_statuses(run_id_list, Status.ENCODED)
 
     def call_for_each_run(self, fn, status=Status.ENCODED):
 

--- a/easyvvuq/worker.py
+++ b/easyvvuq/worker.py
@@ -29,6 +29,12 @@ logger = logging.getLogger(__name__)
 
 
 class Worker:
+    """
+    A Worker is a stripped down version of the Campaign, providing access to runs in the database,
+    encoding etc. The purpose is, for example, to allow encoding/running/decoding of runs to take
+    place in a separate process (script) from the main script.
+    """
+
     def __init__(
             self,
             db_type="sql",
@@ -65,6 +71,9 @@ class Worker:
          self._active_app_decoder) = self.campaign_db.resurrect_app(app_name)
 
     def encode_runs(self, run_id_list):
+        """
+        Runs the encoder for all run ids listed in run_id_list.
+        """
 
         # Get the encoder for this app. If none is set, only the directory structure
         # will be created.
@@ -99,8 +108,9 @@ class Worker:
         self.campaign_db.set_run_statuses(run_id_list, Status.ENCODED)
 
     def call_for_each_run(self, fn, status=Status.ENCODED):
-
-        # Loop through all runs in this campaign with the specified status,
-        # and call the specified user function for each.
+        """
+        Loop through all runs in this campaign with the specified status,
+        and call the specified user function for each.
+        """
         for run_id, run_data in self.campaign_db.runs(status=status):
             fn(run_data['run_dir'], run_data['params'])

--- a/easyvvuq/worker.py
+++ b/easyvvuq/worker.py
@@ -1,12 +1,6 @@
 import os
 import logging
-import json
-import easyvvuq
-from easyvvuq import ParamsSpecification
-from easyvvuq.constants import default_campaign_prefix, Status
-from easyvvuq.data_structs import RunInfo, CampaignInfo, AppInfo
-from easyvvuq.sampling import BaseSamplingElement
-from easyvvuq.collate import BaseCollationElement
+from easyvvuq.constants import Status
 
 __copyright__ = """
 

--- a/easyvvuq/worker.py
+++ b/easyvvuq/worker.py
@@ -33,6 +33,7 @@ __license__ = "LGPL"
 
 logger = logging.getLogger(__name__)
 
+
 class Worker:
     def __init__(
             self,

--- a/easyvvuq/worker.py
+++ b/easyvvuq/worker.py
@@ -1,0 +1,110 @@
+import os
+import logging
+import json
+import easyvvuq
+from easyvvuq import ParamsSpecification
+from easyvvuq.constants import default_campaign_prefix, Status
+from easyvvuq.data_structs import RunInfo, CampaignInfo, AppInfo
+from easyvvuq.sampling import BaseSamplingElement
+from easyvvuq.collate import BaseCollationElement
+
+__copyright__ = """
+
+    Copyright 2018 Robin A. Richardson, David W. Wright
+
+    This file is part of EasyVVUQ
+
+    EasyVVUQ is free software: you can redistribute it and/or modify
+    it under the terms of the Lesser GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    EasyVVUQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    Lesser GNU General Public License for more details.
+
+    You should have received a copy of the Lesser GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+__license__ = "LGPL"
+
+
+logger = logging.getLogger(__name__)
+
+class Worker:
+    def __init__(
+            self,
+            campaign_name=None,
+            app_name=None,
+            db_type="sql",
+            db_location=None
+    ):
+
+        self.campaign_name = campaign_name
+        self.db_type = db_type
+        self.db_location = db_location
+
+        if self.db_type == 'sql':
+            from .db.sql import CampaignDB
+        elif self.db_type == 'json':
+            from .db.json import CampaignDB
+        else:
+            message = (f"Invalid 'db_type' {self.db_type}. Supported types "
+                       f"are 'sql' or 'json'.")
+            logger.critical(message)
+            raise RuntimeError(message)
+
+        # Open session to the database
+        logger.info(f"Opening session with CampaignDB at {self.db_location}")
+        self.campaign_db = CampaignDB(location=self.db_location,
+                                      new_campaign=False,
+                                      name=self.campaign_name)
+        self.campaign_id = self.campaign_db.get_campaign_id(self.campaign_name)
+
+        # Resurrect the app encoder and decoder elements
+        self._active_app_name = app_name
+        self._active_app = self.campaign_db.app(name=app_name)
+        (self._active_app_encoder,
+         self._active_app_decoder) = self.campaign_db.resurrect_app(app_name)
+
+    def encode_runs(self, run_id_list):
+
+        # Get the encoder for this app. If none is set, only the directory structure
+        # will be created.
+        active_encoder = self._active_app_encoder
+        if active_encoder is None:
+            logger.warning('No encoder set for this app. Creating directory structure only.')
+        else:
+            use_fixtures = active_encoder.fixture_support
+            fixtures = self._active_app['fixtures']
+
+        # Loop through all runs in the run_id_list
+        runs_dir = self.campaign_db.runs_dir()
+        for run_id, run_data in self.campaign_db.runs(status=Status.NEW):
+
+            # Make run directory
+            target_dir = os.path.join(runs_dir, run_id)
+            os.makedirs(target_dir)
+
+            self.campaign_db.set_dir_for_run(run_id, target_dir)
+
+            if active_encoder is not None:
+                if use_fixtures:
+                    active_encoder.encode(params=run_data['params'],
+                                          fixtures=fixtures,
+                                          target_dir=target_dir)
+                else:
+                    active_encoder.encode(params=run_data['params'],
+                                          target_dir=target_dir)
+
+            # Update run status in db
+            self.campaign_db.set_run_statuses([run_id], Status.ENCODED)
+
+    def call_for_each_run(self, fn, status=Status.ENCODED):
+
+        # Loop through all runs in this campaign with the specified status,
+        # and call the specified user function for each.
+        for run_id, run_data in self.campaign_db.runs(status=status):
+            fn(run_data['run_dir'], run_data['params'])

--- a/tests/test_cannonsim_csv_call_fn.py
+++ b/tests/test_cannonsim_csv_call_fn.py
@@ -38,8 +38,8 @@ if not os.path.exists("tests/cannonsim/bin/cannonsim"):
 cannonsim_path = os.path.realpath(os.path.expanduser("tests/cannonsim/bin/cannonsim"))
 
 
-def execute_cannonsim(path, params):
-    os.system(f"cd {path} && {cannonsim_path} in.cannon output.csv")
+def execute_cannonsim(run_id, run_data):
+    os.system(f"cd {run_data['run_dir']} && {cannonsim_path} in.cannon output.csv")
 
 
 def test_cannonsim_csv(tmpdir):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,150 @@
+import easyvvuq as uq
+import chaospy as cp
+import os
+import sys
+import pytest
+from pprint import pprint
+
+__copyright__ = """
+
+    Copyright 2018 Robin A. Richardson, David W. Wright
+
+    This file is part of EasyVVUQ
+
+    EasyVVUQ is free software: you can redistribute it and/or modify
+    it under the terms of the Lesser GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    EasyVVUQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    Lesser GNU General Public License for more details.
+
+    You should have received a copy of the Lesser GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+__license__ = "LGPL"
+
+
+# If cannonsim has not been built (to do so, run the Makefile in tests/cannonsim/src/)
+# then skip this test
+if not os.path.exists("tests/cannonsim/bin/cannonsim"):
+    pytest.skip(
+        "Skipping cannonsim test (cannonsim is not installed in tests/cannonsim/bin/)",
+        allow_module_level=True)
+
+
+def test_worker(tmpdir):
+
+    # Set up a fresh campaign called "cannon"
+    my_campaign = uq.Campaign(name='cannon', work_dir=tmpdir)
+
+    # Define parameter space for the cannonsim app
+    params = {
+        "angle": {
+            "type": "float",
+            "min": 0.0,
+            "max": 6.28,
+            "default": 0.79},
+        "air_resistance": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1.0,
+            "default": 0.2},
+        "height": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1000.0,
+            "default": 1.0},
+        "time_step": {
+            "type": "float",
+            "min": 0.0001,
+            "max": 1.0,
+            "default": 0.01},
+        "gravity": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1000.0,
+            "default": 9.8},
+        "mass": {
+            "type": "float",
+            "min": 0.0001,
+            "max": 1000.0,
+            "default": 1.0},
+        "velocity": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1000.0,
+            "default": 10.0}}
+
+    # Create an encoder and decoder for the cannonsim app
+    encoder = uq.encoders.GenericEncoder(
+        template_fname='tests/cannonsim/test_input/cannonsim.template',
+        delimiter='#',
+        target_filename='in.cannon')
+    decoder = uq.decoders.SimpleCSV(
+        target_filename='output.csv', output_columns=[
+            'Dist', 'lastvx', 'lastvy'], header=0)
+
+    # Add the cannonsim app
+    my_campaign.add_app(name="cannonsim",
+                        params=params,
+                        encoder=encoder,
+                        decoder=decoder)
+
+    # Set the active app to be cannonsim (this is redundant when only one app
+    # has been added)
+    my_campaign.set_app("cannonsim")
+
+    # Create a collation element for this campaign
+    collater = uq.collate.AggregateSamples(average=False)
+    my_campaign.set_collater(collater)
+    print("Serialized collation:", collater.serialize())
+
+    # Make a random sampler
+    vary = {
+        "angle": cp.Uniform(0.0, 1.0),
+        "height": cp.Uniform(2.0, 10.0),
+        "velocity": cp.Normal(10.0, 1.0),
+        "mass": cp.Uniform(5.0, 1.0)
+    }
+    sampler1 = uq.sampling.RandomSampler(vary=vary)
+
+    print("Serialized sampler:", sampler1.serialize())
+
+    # Set the campaign to use this sampler
+    my_campaign.set_sampler(sampler1)
+
+    # Draw 5 samples
+    my_campaign.draw_samples(num_samples=5)
+
+    # Print the list of runs now in the campaign db
+    print("List of runs added:")
+    pprint(my_campaign.list_runs())
+    print("---")
+
+    # Use external worker to encode all the runs
+    os.system("python3 easyvvuq/tools/external_encoder.py " + " ".join([my_campaign.db_type, my_campaign.db_location, "cannon", "cannonsim", "Run_1,Run_2"]))
+
+    # Local execution
+    my_campaign.apply_for_each_run_dir(uq.actions.ExecuteLocal(
+        "tests/cannonsim/bin/cannonsim in.cannon output.csv"))
+
+    # Collate all data into one pandas data frame
+    my_campaign.collate()
+    print("data:", my_campaign.get_collation_result())
+
+    # Create a BasicStats analysis element and apply it to the campaign
+    stats = uq.analysis.BasicStats(qoi_cols=['Dist', 'lastvx', 'lastvy'])
+    my_campaign.apply_analysis(stats)
+    print("stats:\n", my_campaign.get_last_analysis())
+
+    # Print the campaign log
+    pprint(my_campaign._log)
+
+    print("All completed?", my_campaign.all_complete())
+
+if __name__ == "__main__":
+    test_worker("/tmp/")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,7 +1,6 @@
 import easyvvuq as uq
 import chaospy as cp
 import os
-import sys
 import pytest
 from pprint import pprint
 
@@ -35,7 +34,7 @@ if not os.path.exists("tests/cannonsim/bin/cannonsim"):
         "Skipping cannonsim test (cannonsim is not installed in tests/cannonsim/bin/)",
         allow_module_level=True)
 
-cannonsim_path = os.path.realpath(os.path.expanduser("tests/cannonsim/bin/cannonsim"))
+CANNONSIM_PATH = os.path.realpath(os.path.expanduser("tests/cannonsim/bin/cannonsim"))
 
 
 def test_worker(tmpdir):
@@ -135,9 +134,11 @@ def test_worker(tmpdir):
             "cannon",
             "cannonsim",
             run_id])
-        os.system("python3 easyvvuq/tools/external_encoder.py " + enc_args)
 
-        os.system(f"cd {run_data['run_dir']} && {cannonsim_path} in.cannon output.csv")
+        encoder_path = f"{uq.__path__[0]}/tools/external_encoder.py"
+        os.system(f"python3 {encoder_path} " + enc_args)
+
+        os.system(f"cd {run_data['run_dir']} && {CANNONSIM_PATH} in.cannon output.csv")
 
     # Encode and execute. Note to call function for all runs with status NEW (and not ENCODED)
     my_campaign.call_for_each_run(encode_and_execute_cannonsim, status=uq.constants.Status.NEW)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -37,6 +37,7 @@ if not os.path.exists("tests/cannonsim/bin/cannonsim"):
 
 cannonsim_path = os.path.realpath(os.path.expanduser("tests/cannonsim/bin/cannonsim"))
 
+
 def test_worker(tmpdir):
 
     # Set up a fresh campaign called "cannon"
@@ -157,6 +158,7 @@ def test_worker(tmpdir):
     pprint(my_campaign._log)
 
     print("All completed?", my_campaign.all_complete())
+
 
 if __name__ == "__main__":
     test_worker("/tmp/")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -126,7 +126,16 @@ def test_worker(tmpdir):
     print("---")
 
     # Use external worker to encode all the runs
-    os.system("python3 easyvvuq/tools/external_encoder.py " + " ".join([my_campaign.db_type, my_campaign.db_location, "cannon", "cannonsim", "Run_1,Run_2"]))
+    enc_args = " ".join([
+        my_campaign.db_type,
+        my_campaign.db_location,
+        "cannon",
+        "cannonsim",
+        "Run_1,Run_2,Run_3,Run_4,Run_5"])
+    os.system("python3 easyvvuq/tools/external_encoder.py " + enc_args)
+
+    print("Runs list after encoding:")
+    pprint(my_campaign.list_runs())
 
     # Local execution
     my_campaign.apply_for_each_run_dir(uq.actions.ExecuteLocal(


### PR DESCRIPTION
First implementation of the Worker concept - a stripped down object to access a campaign database from an external script (i.e. running in another process). This is useful for e.g. encoding a batch of runs in another process, such as is needed for the PSNC PJM case.

I have added an ```external_encoder.py''' tool that is a simple script using a Worker to encode the specified list of runs for the specified campaign database location. It is my intention that this replace all the complex work-around bash scripts that were needed for the first PJM test scripts.

If you want to see an example of how this all fits together, look at the test_worker.py script in tests/. It shows how to encode and execute all the runs entirely externally. The user-defined function is where I'd expect the PJM jobs to be added, using the same (shell) run commands.

As a side effect, this PR also cleans up the populate_runs_dir() nightmare in which the run_dir for each run was not set until the directory was actually created. While this seemed sensible at first, it actually results in the db getting hammered with pointless updates. More seriously, it prevented any sort of PJM usage, because the execution command could not be queued up until the encoder had run, and the db was checked (unnecessarily) to find out where the run files are. In the new approach, a default run_dir is set for any new run, and is assumed to be where all files will end up unless told otherwise. We can still change this path at any time (as before) as long as we have not started the encoding/execution phase, which I think is reasonable.