### PR TITLE
Sampler of samplers

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@ Table of contents
    concepts
    basic_tutorial
    cooling_coffee_cup
+   multisampler_tutorial
    restartable_campaign_tutorial
    custom_encoder
 

--- a/docs/multisampler_tutorial.rst
+++ b/docs/multisampler_tutorial.rst
@@ -1,0 +1,25 @@
+.. _multisampler_tutorial:
+
+Combining multiple samplers using Multisampler
+==============================================
+
+There may be cases in which you want to generate runs using a combination of samplers, each acting
+on a subset of the parameters. For example, one may wish to carry out a Polynomial Chaos Expansion
+on some parameters (x and y), but for a set sequence of some other parameter (z). In such a case
+you would want a sampler that combines a PCE sampler (for x and y) and a Sweep sampler (cycling
+through values of z). There are, of course, far more complex situations than this too.
+
+In EasyVVUQ such a case is addressed using a `Multisampler`. For example, the following ::
+
+    my_multisampler = uq.sampling.MultiSampler(sampler1, sampler2, sampler3)
+
+will create a new sampler which is a combination of `sampler1`, `sampler2` and `sampler3`.
+Here we have combined 3 samplers, but any number of samplers can be used in this manner.
+
+Note that the ordering of the samplers does matter. The last sampler in the list updates 'fastest'
+while the first sampler updates 'slowest'. Furthermore, every sampler in a multisampler must be
+finite (contain a finite number of samples).
+
+Once created, this sampler can be added to the campaign object and used like any other ::
+    my_campaign.set_sampler(my_multisampler)
+    my_campaign.draw_samples()

--- a/docs/multisampler_tutorial.rst
+++ b/docs/multisampler_tutorial.rst
@@ -4,22 +4,23 @@ Combining multiple samplers using Multisampler
 ==============================================
 
 There may be cases in which you want to generate runs using a combination of samplers, each acting
-on a subset of the parameters. For example, one may wish to carry out a Polynomial Chaos Expansion
-on some parameters (x and y), but for a set sequence of some other parameter (z). In such a case
-you would want a sampler that combines a PCE sampler (for x and y) and a Sweep sampler (cycling
-through values of z). There are, of course, far more complex situations than this too.
+on a subset of the parameters.
+For example, one may wish to carry out a Polynomial Chaos Expansion on some parameters (x and y), but for a set sequence of some other parameter (z).
+In such a case you would want a sampler that combines a PCE sampler (for x and y) and a Sweep sampler (cycling through values of z).
+There are, of course, far more complex situations than this too.
 
-In EasyVVUQ such a case is addressed using a `Multisampler`. For example, the following ::
+In EasyVVUQ such a case is addressed using a `Multisampler`.
+For example, the following code creates a new sampler which combines three existing samples (`sampler1`, `sampler2` and `sampler3`): ::
 
     my_multisampler = uq.sampling.MultiSampler(sampler1, sampler2, sampler3)
 
-will create a new sampler which is a combination of `sampler1`, `sampler2` and `sampler3`.
-Here we have combined 3 samplers, but any number of samplers can be used in this manner.
 
-Note that the ordering of the samplers does matter. The last sampler in the list updates 'fastest'
-while the first sampler updates 'slowest'. Furthermore, every sampler in a multisampler must be
-finite (contain a finite number of samples).
+Whilst this example invovles 3 samplers, any number of samplers can be combined in the same manner.
+Note that the ordering of the samplers *does* matter.
+The last sampler in the list updates 'fastest' while the first sampler updates 'slowest'.
+Furthermore, every sampler in a multisampler must be finite (contain a finite number of samples).
 
-Once created, this sampler can be added to the campaign object and used like any other ::
+Once created, this sampler can be added to the campaign object and used like any other: ::
+
     my_campaign.set_sampler(my_multisampler)
     my_campaign.draw_samples()

--- a/docs/multisampler_tutorial.rst
+++ b/docs/multisampler_tutorial.rst
@@ -24,3 +24,5 @@ Once created, this sampler can be added to the campaign object and used like any
 
     my_campaign.set_sampler(my_multisampler)
     my_campaign.draw_samples()
+
+

--- a/easyvvuq/analysis/pce_analysis.py
+++ b/easyvvuq/analysis/pce_analysis.py
@@ -84,7 +84,7 @@ class PCEAnalysis(BaseAnalysisElement):
 
         # Compute nodes and weights
         nodes, weights = cp.generate_quadrature(order=self.sampler.quad_order,
-                                                domain=self.sampler.distribution,
+                                                dist=self.sampler.distribution,
                                                 rule=self.sampler.quad_rule,
                                                 sparse=self.sampler.quad_sparse)
 

--- a/easyvvuq/analysis/qmc_analysis.py
+++ b/easyvvuq/analysis/qmc_analysis.py
@@ -123,7 +123,8 @@ class QMCAnalysis(BaseAnalysisElement):
         return results
 
     # Adapted from SALib
-    def _separate_output_values(self, evaluations, n_uncertain_params, n_samples):
+    @staticmethod
+    def _separate_output_values(evaluations, n_uncertain_params, n_samples):
         evaluations = np.array(evaluations)
 
         shape = (n_samples, n_uncertain_params) + evaluations[0].shape
@@ -138,10 +139,12 @@ class QMCAnalysis(BaseAnalysisElement):
 
         return A, B, AB
 
-    def _first_order(self, A, AB, B):
+    @staticmethod
+    def _first_order(A, AB, B):
         V = np.var(np.r_[A, B], axis=0)
         return np.mean(B * (AB - A), axis=0) / (V + (V == 0)) * (V != 0)
 
-    def _total_order(slef, A, AB, B):
+    @staticmethod
+    def _total_order(A, AB, B):
         V = np.var(np.r_[A, B], axis=0)
         return 0.5 * np.mean((A - AB) ** 2, axis=0) / (V + (V == 0)) * (V != 0)

--- a/easyvvuq/analysis/sc_analysis.py
+++ b/easyvvuq/analysis/sc_analysis.py
@@ -112,7 +112,7 @@ class SCAnalysis(BaseAnalysisElement):
 
         # Compute tensor product nodes and weights
         xi_d, self.wi_d = cp.generate_quadrature(order=self.sampler.quad_order,
-                                                 domain=self.sampler.joint_dist,
+                                                 dist=self.sampler.joint_dist,
                                                  rule=self.sampler.quad_rule)
         self.xi_d = xi_d.T
 

--- a/easyvvuq/sampling/__init__.py
+++ b/easyvvuq/sampling/__init__.py
@@ -4,6 +4,7 @@ from .stochastic_collocation import SCSampler
 from .pce import PCESampler
 from .qmc import QMCSampler
 from .sweep import BasicSweep
+from .sampler_of_samplers import MultiSampler
 
 __copyright__ = """
 

--- a/easyvvuq/sampling/pce.py
+++ b/easyvvuq/sampling/pce.py
@@ -95,7 +95,7 @@ class PCESampler(BaseSamplingElement, sampler_name="PCE_sampler"):
 
         # Nodes and weights for the integration
         self._nodes, _ = cp.generate_quadrature(order=self.quad_order,
-                                                domain=self.distribution,
+                                                dist=self.distribution,
                                                 rule=quadrature_rule,
                                                 sparse=sparse)
 

--- a/easyvvuq/sampling/random.py
+++ b/easyvvuq/sampling/random.py
@@ -58,4 +58,4 @@ class RandomSampler(BaseSamplingElement, sampler_name="random_sampler"):
         return True
 
     def get_restart_dict(self):
-        return {"vary": self.vary.serialize(), "max_num": self.max_num, "count":self.count}
+        return {"vary": self.vary.serialize(), "max_num": self.max_num, "count": self.count}

--- a/easyvvuq/sampling/sampler_of_samplers.py
+++ b/easyvvuq/sampling/sampler_of_samplers.py
@@ -1,6 +1,6 @@
 from .base import BaseSamplingElement
+import logging
 import itertools
-import sys
 
 __copyright__ = """
 
@@ -24,6 +24,8 @@ __copyright__ = """
 """
 __license__ = "LGPL"
 
+logger = logging.getLogger(__name__)
+
 
 class MultiSampler(BaseSamplingElement, sampler_name="multisampler"):
 
@@ -45,7 +47,9 @@ class MultiSampler(BaseSamplingElement, sampler_name="multisampler"):
         # Multisampler is finite only if all samplers in it are finite
         for sampler in self.samplers:
             if sampler.is_finite() is False:
-                sys.exit("Multisampler must be composed of finite samplers")
+                msg = "Multisampler must be composed of finite samplers"
+                logger.critical(msg)
+                raise RuntimeError(msg)
 
         # Combine all the iterables/generators into one
         self.multi_iterator = itertools.product(*self.samplers)

--- a/easyvvuq/sampling/sampler_of_samplers.py
+++ b/easyvvuq/sampling/sampler_of_samplers.py
@@ -78,4 +78,4 @@ class MultiSampler(BaseSamplingElement, sampler_name="multisampler"):
         return True
 
     def get_restart_dict(self):
-        return {'serialized_list_of_samplers':self.serialized_list_of_samplers}
+        return {'serialized_list_of_samplers': self.serialized_list_of_samplers}

--- a/easyvvuq/sampling/sampler_of_samplers.py
+++ b/easyvvuq/sampling/sampler_of_samplers.py
@@ -1,0 +1,57 @@
+from .base import BaseSamplingElement
+
+__copyright__ = """
+
+    Copyright 2018 Robin A. Richardson, David W. Wright
+
+    This file is part of EasyVVUQ
+
+    EasyVVUQ is free software: you can redistribute it and/or modify
+    it under the terms of the Lesser GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    EasyVVUQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    Lesser GNU General Public License for more details.
+
+    You should have received a copy of the Lesser GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+__license__ = "LGPL"
+
+
+class MultiSampler(BaseSamplingElement, sampler_name="multisampler"):
+
+    def __init__(self, *samplers):
+        """
+            Expects one or more samplers
+        """
+        self.samplers = samplers
+
+        # Multisampler is finite only if all samplers in it are finite
+        self.is_finite = True
+        for sampler in self.samplers:
+            if sampler.is_finite() == False:
+                self.is_finite = False
+                break
+
+    def element_version(self):
+        return "0.1"
+
+    def is_finite(self):
+        return self.is_finite
+
+    def __next__(self):
+        run_dict = {}
+        for param_name, dist in self.vary.get_items():
+            run_dict[param_name] = dist.sample(1)[0]
+        return run_dict
+
+    def is_restartable(self):
+        return False
+
+    def get_restart_dict(self):
+        return None

--- a/easyvvuq/sampling/sampler_of_samplers.py
+++ b/easyvvuq/sampling/sampler_of_samplers.py
@@ -44,7 +44,7 @@ class MultiSampler(BaseSamplingElement, sampler_name="multisampler"):
 
         # Multisampler is finite only if all samplers in it are finite
         for sampler in self.samplers:
-            if sampler.is_finite() == False:
+            if sampler.is_finite() is False:
                 sys.exit("Multisampler must be composed of finite samplers")
 
         # Combine all the iterables/generators into one

--- a/easyvvuq/sampling/sampler_of_samplers.py
+++ b/easyvvuq/sampling/sampler_of_samplers.py
@@ -27,11 +27,20 @@ __license__ = "LGPL"
 
 class MultiSampler(BaseSamplingElement, sampler_name="multisampler"):
 
-    def __init__(self, *samplers, count=0):
+    def __init__(self, *samplers, count=0, serialized_list_of_samplers=None):
         """
             Expects one or more samplers
         """
-        self.samplers = samplers
+
+        # If no serialized samplers list passed, generate one. Else deserialize the passed samplers.
+        if serialized_list_of_samplers is None:
+            self.samplers = samplers
+            self.serialized_list_of_samplers = [sampler.serialize() for sampler in self.samplers]
+        else:
+            self.serialized_list_of_samplers = serialized_list_of_samplers
+            self.samplers = []
+            for serialized_sampler in self.serialized_list_of_samplers:
+                self.samplers.append(BaseSamplingElement.deserialize(serialized_sampler))
 
         # Multisampler is finite only if all samplers in it are finite
         for sampler in self.samplers:
@@ -66,7 +75,7 @@ class MultiSampler(BaseSamplingElement, sampler_name="multisampler"):
         return run_dict
 
     def is_restartable(self):
-        return False
+        return True
 
     def get_restart_dict(self):
-        return None
+        return {'serialized_list_of_samplers':self.serialized_list_of_samplers}

--- a/easyvvuq/sampling/sampler_of_samplers.py
+++ b/easyvvuq/sampling/sampler_of_samplers.py
@@ -34,14 +34,9 @@ class MultiSampler(BaseSamplingElement, sampler_name="multisampler"):
         self.samplers = samplers
 
         # Multisampler is finite only if all samplers in it are finite
-        self._is_finite_bool = True
         for sampler in self.samplers:
             if sampler.is_finite() == False:
-                self._is_finite_bool = False
-                break
-
-        if self._is_finite_bool == False:
-            sys.exit("Multisampler must be composed of finite samplers")
+                sys.exit("Multisampler must be composed of finite samplers")
 
         # Combine all the iterables/generators into one
         self.multi_iterator = itertools.product(*self.samplers)
@@ -57,7 +52,7 @@ class MultiSampler(BaseSamplingElement, sampler_name="multisampler"):
         return "0.1"
 
     def is_finite(self):
-        return self._is_finite_bool
+        return True
 
     def __next__(self):
         # Will raise StopIteration when there are none left

--- a/easyvvuq/sampling/sampler_of_samplers.py
+++ b/easyvvuq/sampling/sampler_of_samplers.py
@@ -46,14 +46,12 @@ class MultiSampler(BaseSamplingElement, sampler_name="multisampler"):
         # Combine all the iterables/generators into one
         self.multi_iterator = itertools.product(*self.samplers)
 
-        print(self.multi_iterator)
-
         self.count = 0
-#        for i in range(count):
-#            try:
-#                self.__next__()
-#            except StopIteration:
-#                logger.warning("Multisampler constructed, but has no samples left to draw.")
+        for i in range(count):
+            try:
+                self.__next__()
+            except StopIteration:
+                logger.warning("Multisampler constructed, but has no samples left to draw.")
 
     def element_version(self):
         return "0.1"
@@ -65,11 +63,9 @@ class MultiSampler(BaseSamplingElement, sampler_name="multisampler"):
         # Will raise StopIteration when there are none left
         multisampler_run = self.multi_iterator.__next__()
 
-        print("ES", multisampler_run)
-
         run_dict = {}
-#        for var_name, value in multisampler_run:
-#            run_dict[var_name] = value
+        for contribution in multisampler_run:
+            run_dict = {**run_dict, **contribution}
 
         self.count += 1
         return run_dict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 pandas>=0.24
 scipy
-chaospy
+chaospy=3.0.4
 SALib
 pytest
 pytest-pep8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 pandas>=0.24
 scipy
-chaospy=3.0.4
+chaospy==3.0.4
 SALib
 pytest
 pytest-pep8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 pandas>=0.24
 scipy
-chaospy==3.0.4
+chaospy
 SALib
 pytest
 pytest-pep8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 pandas>=0.24
 scipy
-chaospy
+chaospy>=3.0.7
 SALib
 pytest
 pytest-pep8

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -194,7 +194,7 @@ def test_cannonsim(tmpdir, campaign):
     sampler = uq.sampling.RandomSampler(vary=vary)
     campaign(tmpdir, 'cannon', 'cannonsim', params, encoder, decoder, sampler,
              collater, actions, stats, vary, 5, 1)
-    #campaign(tmpdir, 'cannon', 'cannonsim', params, encoder, decoder, sampler,
+    # campaign(tmpdir, 'cannon', 'cannonsim', params, encoder, decoder, sampler,
     #         collater, None, stats, vary, 5, 1, call_fn=execute_cannonsim)
     # Make a sweep sampler
     sweep = {

--- a/tests/test_multisampler.py
+++ b/tests/test_multisampler.py
@@ -106,29 +106,42 @@ def test_worker(tmpdir):
     my_campaign.set_collater(collater)
 
     # Make a random sampler
-    vary = {
-        "angle": cp.Uniform(0.0, 1.0),
-        "height": cp.Uniform(2.0, 10.0),
-        "velocity": cp.Normal(10.0, 1.0),
-        "mass": cp.Uniform(5.0, 1.0)
+#    vary = {
+#        "angle": cp.Uniform(0.0, 1.0),
+#        "height": cp.Uniform(2.0, 10.0),
+#        "velocity": cp.Normal(10.0, 1.0),
+#        "mass": cp.Uniform(5.0, 1.0)
+#    }
+#    sampler1 = uq.sampling.RandomSampler(vary=vary)
+
+    sweep1 = {
+        "angle": [0.1, 0.2, 0.3],
+        "height": [2.0, 10.0],
+        "velocity": [10.0, 10.1, 10.2]
     }
-    sampler1 = uq.sampling.RandomSampler(vary=vary)
+    sampler1 = uq.sampling.BasicSweep(sweep=sweep1)
+
+    sweep2 = {
+        "gravity": [9.8, 10.8],
+        "mass": [10, 17, 27]
+    }
+    sampler2 = uq.sampling.BasicSweep(sweep=sweep2)
 
     # Make a multisampler
-    multisampler = uq.sampling.MultiSampler(sampler1)
+    multisampler = uq.sampling.MultiSampler(sampler1, sampler2)
 
     # Set the campaign to use this sampler
     my_campaign.set_sampler(multisampler)
 
-    sys.exit(0)
-
-    # Draw 5 samples
-    my_campaign.draw_samples(num_samples=5)
+    # Draw all samples
+    my_campaign.draw_samples()
 
     # Print the list of runs now in the campaign db
     print("List of runs added:")
     pprint(my_campaign.list_runs())
     print("---")
+
+    sys.exit(0)
 
     # User defined function
     def encode_and_execute_cannonsim(run_id, run_data):

--- a/tests/test_multisampler.py
+++ b/tests/test_multisampler.py
@@ -138,8 +138,6 @@ def test_worker(tmpdir):
     pprint(my_campaign.list_runs())
     print("---")
 
-    sys.exit(0)
-
     # User defined function
     def encode_and_execute_cannonsim(run_id, run_data):
         enc_args = [

--- a/tests/test_multisampler.py
+++ b/tests/test_multisampler.py
@@ -132,7 +132,7 @@ def test_worker(tmpdir):
 
     # Test reloading
     my_campaign.save_state(tmpdir + "test_multisampler.json")
-    reloaded_campaign = uq.Campaign(state_file=tmpdir+"test_multisampler.json", work_dir=tmpdir)
+    reloaded_campaign = uq.Campaign(state_file=tmpdir + "test_multisampler.json", work_dir=tmpdir)
 
     # Draw all samples
     my_campaign.draw_samples()

--- a/tests/test_multisampler.py
+++ b/tests/test_multisampler.py
@@ -1,0 +1,168 @@
+import easyvvuq as uq
+import chaospy as cp
+import os
+import sys
+import pytest
+from pprint import pprint
+import subprocess
+
+__copyright__ = """
+
+    Copyright 2018 Robin A. Richardson, David W. Wright
+
+    This file is part of EasyVVUQ
+
+    EasyVVUQ is free software: you can redistribute it and/or modify
+    it under the terms of the Lesser GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    EasyVVUQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    Lesser GNU General Public License for more details.
+
+    You should have received a copy of the Lesser GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+__license__ = "LGPL"
+
+
+# If cannonsim has not been built (to do so, run the Makefile in tests/cannonsim/src/)
+# then skip this test
+if not os.path.exists("tests/cannonsim/bin/cannonsim"):
+    pytest.skip(
+        "Skipping cannonsim test (cannonsim is not installed in tests/cannonsim/bin/)",
+        allow_module_level=True)
+
+CANNONSIM_PATH = os.path.realpath(os.path.expanduser("tests/cannonsim/bin/cannonsim"))
+
+
+def test_worker(tmpdir):
+
+    # Set up a fresh campaign called "cannon"
+    my_campaign = uq.Campaign(name='cannon', work_dir=tmpdir)
+
+    # Define parameter space for the cannonsim app
+    params = {
+        "angle": {
+            "type": "float",
+            "min": 0.0,
+            "max": 6.28,
+            "default": 0.79},
+        "air_resistance": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1.0,
+            "default": 0.2},
+        "height": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1000.0,
+            "default": 1.0},
+        "time_step": {
+            "type": "float",
+            "min": 0.0001,
+            "max": 1.0,
+            "default": 0.01},
+        "gravity": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1000.0,
+            "default": 9.8},
+        "mass": {
+            "type": "float",
+            "min": 0.0001,
+            "max": 1000.0,
+            "default": 1.0},
+        "velocity": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1000.0,
+            "default": 10.0}}
+
+    # Create an encoder and decoder for the cannonsim app
+    encoder = uq.encoders.GenericEncoder(
+        template_fname='tests/cannonsim/test_input/cannonsim.template',
+        delimiter='#',
+        target_filename='in.cannon')
+    decoder = uq.decoders.SimpleCSV(
+        target_filename='output.csv', output_columns=[
+            'Dist', 'lastvx', 'lastvy'], header=0)
+
+    # Add the cannonsim app
+    my_campaign.add_app(name="cannonsim",
+                        params=params,
+                        encoder=encoder,
+                        decoder=decoder)
+
+    # Set the active app to be cannonsim (this is redundant when only one app
+    # has been added)
+    my_campaign.set_app("cannonsim")
+
+    # Create a collation element for this campaign
+    collater = uq.collate.AggregateSamples(average=False)
+    my_campaign.set_collater(collater)
+
+    # Make a random sampler
+    vary = {
+        "angle": cp.Uniform(0.0, 1.0),
+        "height": cp.Uniform(2.0, 10.0),
+        "velocity": cp.Normal(10.0, 1.0),
+        "mass": cp.Uniform(5.0, 1.0)
+    }
+    sampler1 = uq.sampling.RandomSampler(vary=vary)
+
+    # Make a multisampler
+    multisampler = uq.sampling.MultiSampler(sampler1)
+
+    # Set the campaign to use this sampler
+    my_campaign.set_sampler(multisampler)
+
+    sys.exit(0)
+
+    # Draw 5 samples
+    my_campaign.draw_samples(num_samples=5)
+
+    # Print the list of runs now in the campaign db
+    print("List of runs added:")
+    pprint(my_campaign.list_runs())
+    print("---")
+
+    # User defined function
+    def encode_and_execute_cannonsim(run_id, run_data):
+        enc_args = [
+            my_campaign.db_type,
+            my_campaign.db_location,
+            "cannon",
+            "cannonsim",
+            run_id
+        ]
+        encoder_path = os.path.realpath(os.path.expanduser("easyvvuq/tools/external_encoder.py"))
+        subprocess.run(['python3', encoder_path] + enc_args)
+        subprocess.run([CANNONSIM_PATH, "in.cannon", "output.csv"], cwd=run_data['run_dir'])
+
+    # Encode and execute. Note to call function for all runs with status NEW (and not ENCODED)
+    my_campaign.call_for_each_run(encode_and_execute_cannonsim, status=uq.constants.Status.NEW)
+
+    print("Runs list after encoding and execution:")
+    pprint(my_campaign.list_runs())
+
+    # Collate all data into one pandas data frame
+    my_campaign.collate()
+    print("data:", my_campaign.get_collation_result())
+
+    # Create a BasicStats analysis element and apply it to the campaign
+    stats = uq.analysis.BasicStats(qoi_cols=['Dist', 'lastvx', 'lastvy'])
+    my_campaign.apply_analysis(stats)
+    print("stats:\n", my_campaign.get_last_analysis())
+
+    # Print the campaign log
+    pprint(my_campaign._log)
+
+    print("All completed?", my_campaign.all_complete())
+
+
+if __name__ == "__main__":
+    test_worker("/tmp/")

--- a/tests/test_multisampler.py
+++ b/tests/test_multisampler.py
@@ -105,15 +105,7 @@ def test_worker(tmpdir):
     collater = uq.collate.AggregateSamples(average=False)
     my_campaign.set_collater(collater)
 
-    # Make a random sampler
-#    vary = {
-#        "angle": cp.Uniform(0.0, 1.0),
-#        "height": cp.Uniform(2.0, 10.0),
-#        "velocity": cp.Normal(10.0, 1.0),
-#        "mass": cp.Uniform(5.0, 1.0)
-#    }
-#    sampler1 = uq.sampling.RandomSampler(vary=vary)
-
+    # Set up samplers
     sweep1 = {
         "angle": [0.1, 0.2, 0.3],
         "height": [2.0, 10.0],
@@ -122,13 +114,18 @@ def test_worker(tmpdir):
     sampler1 = uq.sampling.BasicSweep(sweep=sweep1)
 
     sweep2 = {
-        "gravity": [9.8, 10.8],
-        "mass": [10, 17, 27]
+        "air_resistance": [0.2, 0.3, 0.4]
     }
     sampler2 = uq.sampling.BasicSweep(sweep=sweep2)
 
+    vary = {
+        "gravity": cp.Uniform(9.8, 1.0),
+        "mass": cp.Uniform(2.0, 10.0),
+    }
+    sampler3 = uq.sampling.RandomSampler(vary=vary)
+
     # Make a multisampler
-    multisampler = uq.sampling.MultiSampler(sampler1, sampler2)
+    multisampler = uq.sampling.MultiSampler(sampler1, sampler2, sampler3)
 
     # Set the campaign to use this sampler
     my_campaign.set_sampler(multisampler)

--- a/tests/test_multisampler.py
+++ b/tests/test_multisampler.py
@@ -122,7 +122,7 @@ def test_worker(tmpdir):
         "gravity": cp.Uniform(9.8, 1.0),
         "mass": cp.Uniform(2.0, 10.0),
     }
-    sampler3 = uq.sampling.RandomSampler(vary=vary)
+    sampler3 = uq.sampling.RandomSampler(vary=vary, max_num=5)
 
     # Make a multisampler
     multisampler = uq.sampling.MultiSampler(sampler1, sampler2, sampler3)


### PR DESCRIPTION
I've implemented the sampler-of-samplers idea here. Basically, there is now a sampler called ```Multisampler``` which you can construct as follows:

```
Multisampler(sampler1, sampler2, sampler3, ...)
```

to chain together as many samplers as you wish. Each sampler can be handling a different subset of the variables for a given run. e.g. use a sweep sampler (for vars x and y) in combination with a random sampler (for vars z, w etc).

There is a test/example script of this working in ```tests/test_multisampler.py```. Serialization/deserialization is also implemented.