### PR TITLE
Issue 143 move collation to app

### DIFF
--- a/docs/basic_tutorial.rst
+++ b/docs/basic_tutorial.rst
@@ -211,12 +211,21 @@ and the columns to keep in the data for analysis::
                 output_columns=['Step', 'Value'],
                 header=0)
 
+We will also need to bring the output data together in a single data structure for analysis.
+This is called *collation* in EasyVVUQ teminology.
+Here we use the *AggregateSamples* element to add the output from each *Decoder* to
+a summary `pandas.DataFrame` (the average option here means that rather than have
+data from each step in each run we use the mean to represent each one)::
+
+    collater = uq.collate.AggregateSamples(average=True)
+
 These choices are then added to the *Campaign*::
 
     my_campaign.add_app(name="gauss",
                         params=params,
                         encoder=encoder,
-                        decoder=decoder
+                        decoder=decoder,
+                        collater=collater
                         )
 
 Section 4: Specify Sampler
@@ -245,20 +254,7 @@ Real world examples are likely to use more complicated algorithms (such as
 quasi-Monte Carlo or stochastic collocation) but the way of specifying
 parameters to vary remains the same.
 
-Section 5: Specify Collater
-------------------------------------
-
-We will also need to bring the output data together in a single data structure for analysis.
-This is called *collation* in EasyVVUQ teminology.
-Here we use the *AggregateSamples* element to add the output from each *Decoder* to
-a summary `pandas.DataFrame` (the average option here means that rather than have
-data from each step in each run we use the mean to represent each one)::
-
-    collater = uq.collate.AggregateSamples(average=True)
-
-    my_campaign.set_collater(collater)
-
-Section 6: Get Run Parameters
+Section 5: Get Run Parameters
 -----------------------------
 
 Now that the *Campaign* is setup it can provide sets of parameters to
@@ -272,7 +268,7 @@ Here we have chosen to have 5 replicas (repeats) of each sample drawn.
 At this stage all that happens is the parameter sets are added to the
 *CampaignDB*, no input files have been generated.
 
-Section 7: Create Input Directories
+Section 6: Create Input Directories
 -----------------------------------
 
 We now need to create the input files for each run.
@@ -281,7 +277,7 @@ and uses the specified *Encoder* to produce the appropriate input files::
 
     my_campaign.populate_runs_dir()
 
-Section 8: Run Application
+Section 7: Run Application
 --------------------------
 
 To create our samples we need to execute all of the runs.
@@ -292,7 +288,7 @@ command we specified in Step 0::
 
     my_campaign.apply_for_each_run_dir(uq.actions.ExecuteLocal(cmd))
 
-Section 9: Collate Output
+Section 8: Collate Output
 -------------------------
 
 The collection of simulation output simply handled by the *Campaign*::
@@ -304,7 +300,7 @@ the current application, and the set *Collation* element to produce a summary
 `pandas.DataFrame` including data from all runs. Each time this method is called,
 it will append any new results to the dataframe.
 
-Section 10: Run Analysis
+Section 9: Run Analysis
 -----------------------
 
 The final element in the workflow is the analysis.

--- a/docs/cooling_coffee_cup.rst
+++ b/docs/cooling_coffee_cup.rst
@@ -67,10 +67,14 @@ In this example the GenericEncoder and SimpleCSV, both included in the core Easy
         template_fname='tests/cooling/cooling.template',
         delimiter='$',
         target_filename='cooling_in.json')
-    
+
     decoder = uq.decoders.SimpleCSV(target_filename="output.csv",
                                 output_columns=["te", "ti"],
                                 header=0)
+
+In this workflow all application runs will be analyzed as individual datapoint, so we set the collator to AggregateSamples without averaging. This element simply extracts information using the assigned decoder and adds it to a summary dataframe. ::
+
+    collater = uq.collate.AggregateSamples(average=False)
 
 GenericEncoder performs simple text substitution into a supplied template, using a specified delimiter to identify where parameters should be placed.
 The template is shown below (\$ is used as the delimiter).
@@ -84,21 +88,14 @@ In such cases, users may write their own encoders by extending the BaseEncoder c
        "out_file":"$out_file"
     }
 
-As can be inferred from its name SimpleCSV reads CVS files produced by the cooling model code. Again many applications output results in different formats, potentially requiring bespoke Decoders. Having created an encoder, decoder and parameter space definition for our `cooling' app, we can add it to our campaign. ::
+As can be inferred from its name SimpleCSV reads CVS files produced by the cooling model code. Again many applications output results in different formats, potentially requiring bespoke Decoders. Having created an encoder, decoder and parameter space definition for our `cooling` app, we can add it to our campaign. ::
 
     # Add the app (automatically set as current app)
     my_campaign.add_app(name="cooling",
                         params=params,
                         encoder=encoder,
-                        decoder=decoder)
-
-Set a Collater
---------------
-
-In this workflow all application runs will be analyzed as individual datapoint, so we set the collator to AggregateSamples without averaging. This element simply extracts information using the assigned decoder and adds it to a summary dataframe. ::
-
-    collater = uq.collate.AggregateSamples(average=False)
-    my_campaign.set_collater(collater)
+                        decoder=decoder,
+                        collater=collater)
 
 The Sampler
 -----------

--- a/docs/tutorial_files/cooling_model.py
+++ b/docs/tutorial_files/cooling_model.py
@@ -41,7 +41,7 @@ output_filename = inputs['out_file']
 te = model(t, temp0, kappa, t_env)
 ti = -te
 # output csv file
-header = 'te, ti'
+header = 'te,ti'
 np.savetxt(output_filename, np.c_[te, ti],
            delimiter=",", comments='',
            header=header)

--- a/docs/tutorial_files/easyvvuq_gauss_tutorial.py
+++ b/docs/tutorial_files/easyvvuq_gauss_tutorial.py
@@ -44,6 +44,7 @@ params = {
 
 # 3. Wrap Application
 #    - Define a new application (we'll call it 'gauss'), and the encoding/decoding elements it needs
+#    - Also requires a collation element - his will be responsible for aggregating the results
 encoder = uq.encoders.GenericEncoder(template_fname=template,
                                      target_filename=input_filename)
 
@@ -52,18 +53,16 @@ decoder = uq.decoders.SimpleCSV(
             output_columns=['Step', 'Value'],
             header=0)
 
+collater = uq.collate.AggregateSamples(average=True)
+
 my_campaign.add_app(name="gauss",
                     params=params,
                     encoder=encoder,
-                    decoder=decoder
+                    decoder=decoder,
+                    collater=collater
                     )
 
-# 4. Set a collation element
-#    - This will be responsible for aggregating the results
-collater = uq.collate.AggregateSamples(average=True)
-my_campaign.set_collater(collater)
-
-# 5. Specify Sampler
+# 4. Specify Sampler
 #    -  vary the `mu` parameter only
 vary = {
     "mu": cp.Uniform(1.0, 100.0),
@@ -73,22 +72,24 @@ my_sampler = uq.sampling.RandomSampler(vary=vary)
 
 my_campaign.set_sampler(my_sampler)
 
-# 6. Get run parameters
+# 5. Get run parameters
 my_campaign.draw_samples(num_samples=3,
                          replicas=5)
 
-# 7. Create run input directories
+# 6. Create run input directories
 my_campaign.populate_runs_dir()
 
-# 8. Run Application
+print(my_campaign)
+
+# 7. Run Application
 #    - gauss is executed for each sample
 my_campaign.apply_for_each_run_dir(uq.actions.ExecuteLocal(cmd,
                                                            interpret='python3'))
 
-# 9. Collate output
+# 8. Collate output
 my_campaign.collate()
 
-# 10. Run Analysis
+# 9. Run Analysis
 #     - Calculate bootstrap statistics for collated data
 stats = uq.analysis.EnsembleBoot(groupby=["mu"], qoi_cols=["Value"])
 my_campaign.apply_analysis(stats)

--- a/docs/tutorial_files/easyvvuq_restart_campaign_tutorial.py
+++ b/docs/tutorial_files/easyvvuq_restart_campaign_tutorial.py
@@ -45,6 +45,7 @@ params = {
 
 # 3. Wrap Application
 #    - Define a new application (we'll call it 'gauss'), and the encoding/decoding elements it needs
+#    - Also requires a collation element - his will be responsible for aggregating the results
 encoder = uq.encoders.GenericEncoder(template_fname=template,
                                      target_filename=input_filename)
 
@@ -53,18 +54,16 @@ decoder = uq.decoders.SimpleCSV(
             output_columns=['Step', 'Value'],
             header=0)
 
+collater = uq.collate.AggregateSamples(average=True)
+
 my_campaign.add_app(name="gauss",
                     params=params,
                     encoder=encoder,
-                    decoder=decoder
+                    decoder=decoder,
+                    collater=collater
                     )
 
-# 4. Set a collation element
-#    - This will be responsible for aggregating the results
-collater = uq.collate.AggregateSamples(average=True)
-my_campaign.set_collater(collater)
-
-# 5. Specify Sampler
+# 4. Specify Sampler
 #    -  vary the `mu` parameter only
 vary = {
     "mu": cp.Uniform(1.0, 100.0),
@@ -74,39 +73,39 @@ my_sampler = uq.sampling.RandomSampler(vary=vary)
 
 my_campaign.set_sampler(my_sampler)
 
-# 6. Get run parameters
+# 5. Get run parameters
 my_campaign.draw_samples(num_samples=3, replicas=5)
 
-# 7. Create run input directories
+# 6. Create run input directories
 my_campaign.populate_runs_dir()
 
-# 8. Run Application
+# 7. Run Application
 #    - gauss is executed for each sample
 my_campaign.apply_for_each_run_dir(uq.actions.ExecuteLocal(cmd, interpret='python3'))
 
-# 9. Collate output
+# 8. Collate output
 my_campaign.collate()
 
-# 10. Print the list of runs
+# 9. Print the list of runs
 pprint(my_campaign.list_runs())
 
-# 11. Save the Campaign
+# 10. Save the Campaign
 my_campaign.save_state("campaign_state.json")
 
-# 12. Load state in new campaign object
+# 11. Load state in new campaign object
 print("Reloading campaign...")
 reloaded_campaign = uq.Campaign(state_file="campaign_state.json", work_dir=".")
 
-# 13. Draw some more samples, execute the runs, and collate onto existing dataframe
+# 12. Draw some more samples, execute the runs, and collate onto existing dataframe
 reloaded_campaign.draw_samples(num_samples=1, replicas=5)
 reloaded_campaign.populate_runs_dir()
 my_campaign.apply_for_each_run_dir(uq.actions.ExecuteLocal(cmd, interpret='python3'))
 reloaded_campaign.collate()
 
-# 14. Print the list of runs again
+# 13. Print the list of runs again
 pprint(reloaded_campaign.list_runs())
 
-# 15. Run Analysis
+# 14. Run Analysis
 #     - Calculate bootstrap statistics for collated data
 stats = uq.analysis.EnsembleBoot(groupby=["mu"], qoi_cols=["Value"])
 my_campaign.apply_analysis(stats)

--- a/docs/tutorial_files/gauss.py
+++ b/docs/tutorial_files/gauss.py
@@ -52,7 +52,6 @@ if 'biasfile' in inputs:
 else:
     bias = 0
 
-
 if num_steps <= 0:
     sys.exit("num_steps should be > 0")
 
@@ -63,4 +62,4 @@ numbers_out = np.array(list(enumerate(numbers)))
 header = 'Step,Value'
 
 fmt = '%i,%f'
-np.savetxt(output_filename, numbers_out, fmt=fmt, header=header)
+np.savetxt(output_filename, numbers_out, fmt=fmt, header=header, comments='')

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -280,7 +280,7 @@ class Campaign:
         self.campaign_id = campaign_db.get_campaign_id(self.campaign_name)
 
         # Resurrect the sampler
-        sampler_id = campaign_db.get_sampler_id(self.campaign_id)
+        self._active_sampler_id = campaign_db.get_sampler_id(self.campaign_id)
         self._active_sampler = campaign_db.resurrect_sampler(self._active_sampler_id)
 
         self.set_app(self._active_app_name)
@@ -401,7 +401,7 @@ class Campaign:
         self._active_app_name = app_name
         self._active_app = self.campaign_db.app(name=app_name)
 
-        # Resurrect the app encoder and decoder elements
+        # Resurrect the app encoder, decoder and collation elements
         (self._active_app_encoder,
          self._active_app_decoder,
          self._active_app_collater) = self.campaign_db.resurrect_app(app_name)

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -12,7 +12,6 @@ from easyvvuq import ParamsSpecification
 from easyvvuq.constants import default_campaign_prefix, Status
 from easyvvuq.data_structs import RunInfo, CampaignInfo, AppInfo
 from easyvvuq.sampling import BaseSamplingElement
-from easyvvuq.collate import BaseCollationElement
 
 __copyright__ = """
 

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -339,7 +339,7 @@ class Campaign:
             raise RuntimeError(message)
 
     def add_app(self, name=None, params=None, fixtures=None,
-                encoder=None, decoder=None,
+                encoder=None, decoder=None, collater=None,
                 set_active=True):
         """Add an application to the CampaignDB.
 
@@ -356,6 +356,8 @@ class Campaign:
         decoder : :obj:`easyvvuq.decoders.base.BaseDecoder`
             Decoder element to convert application run output into data for
             VVUQ analysis.
+        collater : obj:`easyvvuq.collate.base.BaseCollationElement`
+            Collation element for this app.
         set_active: bool
             Should the added app be set to be the currently active app?
 
@@ -373,7 +375,8 @@ class Campaign:
             paramsspec=paramsspec,
             fixtures=fixtures,
             encoder=encoder,
-            decoder=decoder
+            decoder=decoder,
+            collater=collater
         )
 
         self.campaign_db.add_app(app)
@@ -424,25 +427,25 @@ class Campaign:
         self._active_sampler_id = self.campaign_db.add_sampler(sampler)
         self.campaign_db.set_sampler(self.campaign_id, self._active_sampler_id)
 
-    def set_collater(self, collater):
-        """Set a collater for this campaign.
-
-        Parameters
-        ----------
-        collater : `easyvvuq.collate.base.BaseCollationElement`
-            Collation that will be used to create runs for the current campaign.
-
-        Returns
-        -------
-
-        """
-        if not isinstance(collater, BaseCollationElement):
-            msg = "set_collater() must be passed a collation element"
-            logging.error(msg)
-            raise Exception(msg)
-
-        self.campaign_db.set_campaign_collater(collater, self.campaign_id)
-        self._active_collater = collater
+#    def set_collater(self, collater):
+#        """Set a collater for this campaign.
+#
+#        Parameters
+#        ----------
+#        collater : `easyvvuq.collate.base.BaseCollationElement`
+#            Collation that will be used to create runs for the current campaign.
+#
+#        Returns
+#        -------
+#
+#        """
+#        if not isinstance(collater, BaseCollationElement):
+#            msg = "set_collater() must be passed a collation element"
+#            logging.error(msg)
+#            raise Exception(msg)
+#
+#        self.campaign_db.set_campaign_collater(collater, self.campaign_id)
+#        self._active_collater = collater
 
     def add_runs(self, runs):
         """Add a new run to the queue.

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -664,7 +664,7 @@ class Campaign:
         """
 
         # Apply collation element
-        num_collated = self._active_app_collater.collate(self)
+        num_collated = self._active_app_collater.collate(self, self._active_app['id'])
 
         if num_collated < 1:
             logger.warning("No data collected during collation.")
@@ -685,7 +685,7 @@ class Campaign:
             pandas dataframe
 
         """
-        return self._active_app_collater.get_collated_dataframe()
+        return self._active_app_collater.get_collated_dataframe(self._active_app['id'])
 
     def apply_analysis(self, analysis):
         """Run the `analysis` element on the output of the last run collation.
@@ -772,3 +772,6 @@ class Campaign:
         """
 
         return self._active_sampler
+
+    def get_active_app(self):
+        return self._active_app

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -282,7 +282,6 @@ class Campaign:
         # Resurrect the sampler and collation elements
         self._active_sampler_id = campaign_db.get_sampler_id(self.campaign_id)
         self._active_sampler = campaign_db.resurrect_sampler(self._active_sampler_id)
-        self._active_app_collater = campaign_db.resurrect_collation(self.campaign_id)
 
         self.set_app(self._active_app_name)
 

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -595,7 +595,8 @@ class Campaign:
 
         run_ids = []
 
-        for run_id, run_data in self.campaign_db.runs(status=Status.NEW, app_id=self._active_app['id']):
+        for run_id, run_data in self.campaign_db.runs(
+                status=Status.NEW, app_id=self._active_app['id']):
 
             # Make directory for this run's output
             os.makedirs(run_data['run_dir'])

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -427,26 +427,6 @@ class Campaign:
         self._active_sampler_id = self.campaign_db.add_sampler(sampler)
         self.campaign_db.set_sampler(self.campaign_id, self._active_sampler_id)
 
-#    def set_collater(self, collater):
-#        """Set a collater for this campaign.
-#
-#        Parameters
-#        ----------
-#        collater : `easyvvuq.collate.base.BaseCollationElement`
-#            Collation that will be used to create runs for the current campaign.
-#
-#        Returns
-#        -------
-#
-#        """
-#        if not isinstance(collater, BaseCollationElement):
-#            msg = "set_collater() must be passed a collation element"
-#            logging.error(msg)
-#            raise Exception(msg)
-#
-#        self.campaign_db.set_campaign_collater(collater, self.campaign_id)
-#        self._active_collater = collater
-
     def add_runs(self, runs):
         """Add a new run to the queue.
 

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -106,7 +106,7 @@ class Campaign:
         The current Encoder object being used, from the currently set app
     _active_app_decoder: easyvvuq.decoders.BaseDecoder
         The current Decoder object being used, from the currently set app
-    _active_collater: easyvvuq.collate.BaseCollationElement
+    _active_app_collater: easyvvuq.collate.BaseCollationElement
         The current Collater object assigned to this campaign
     _active_sampler: easyvvuq.sampling.BaseSamplingElement
         The currently set Sampler object
@@ -144,8 +144,8 @@ class Campaign:
         self._active_app_name = None
         self._active_app_encoder = None
         self._active_app_decoder = None
+        self._active_app_collater = None
 
-        self._active_collater = None
         self._active_sampler = None
         self._active_sampler_id = None
 
@@ -282,7 +282,7 @@ class Campaign:
         # Resurrect the sampler and collation elements
         self._active_sampler_id = campaign_db.get_sampler_id(self.campaign_id)
         self._active_sampler = campaign_db.resurrect_sampler(self._active_sampler_id)
-        self._active_collater = campaign_db.resurrect_collation(self.campaign_id)
+        self._active_app_collater = campaign_db.resurrect_collation(self.campaign_id)
 
         self.set_app(self._active_app_name)
 
@@ -404,7 +404,8 @@ class Campaign:
 
         # Resurrect the app encoder and decoder elements
         (self._active_app_encoder,
-         self._active_app_decoder) = self.campaign_db.resurrect_app(app_name)
+         self._active_app_decoder,
+         self._active_app_collater) = self.campaign_db.resurrect_app(app_name)
 
     def set_sampler(self, sampler):
         """Set active sampler.
@@ -676,7 +677,7 @@ class Campaign:
     def collate(self):
         """Combine the output from all runs associated with the current app.
 
-        Uses the collation element held in `self._active_collater`.
+        Uses the collation element held in `self._active_app_collater`.
 
         Returns
         -------
@@ -684,14 +685,14 @@ class Campaign:
         """
 
         # Apply collation element
-        num_collated = self._active_collater.collate(self)
+        num_collated = self._active_app_collater.collate(self)
 
         if num_collated < 1:
             logger.warning("No data collected during collation.")
 
         # Log application of this collation element
         info = {'num_collated': num_collated}
-        self.log_element_application(self._active_collater, info)
+        self.log_element_application(self._active_app_collater, info)
 
     def get_collation_result(self):
         """
@@ -705,7 +706,7 @@ class Campaign:
             pandas dataframe
 
         """
-        return self._active_collater.get_collated_dataframe()
+        return self._active_app_collater.get_collated_dataframe()
 
     def apply_analysis(self, analysis):
         """Run the `analysis` element on the output of the last run collation.

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -595,7 +595,7 @@ class Campaign:
 
         run_ids = []
 
-        for run_id, run_data in self.campaign_db.runs(status=Status.NEW):
+        for run_id, run_data in self.campaign_db.runs(status=Status.NEW, app_id=self._active_app['id']):
 
             # Make directory for this run's output
             os.makedirs(run_data['run_dir'])
@@ -628,10 +628,10 @@ class Campaign:
 
         # Loop through all runs in this campaign with the specified status,
         # and call the specified user function for each.
-        for run_id, run_data in self.campaign_db.runs(status=status):
+        for run_id, run_data in self.campaign_db.runs(status=status, app_id=self._active_app['id']):
             fn(run_id, run_data)
 
-    def apply_for_each_run_dir(self, action):
+    def apply_for_each_run_dir(self, action, status=Status.ENCODED):
         """
         For each run in this Campaign's run list, apply the specified action
         (an object of type Action)
@@ -648,7 +648,7 @@ class Campaign:
 
         # Loop through all runs in this campaign with status ENCODED, and
         # run the specified action on each run's dir
-        for run_id, run_data in self.campaign_db.runs(status=Status.ENCODED):
+        for run_id, run_data in self.campaign_db.runs(status=status, app_id=self._active_app['id']):
             logger.info("Applying " + action.__module__ + " to " + run_data['run_dir'])
             action.act_on_dir(run_data['run_dir'])
 

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -684,7 +684,7 @@ class Campaign:
             pandas dataframe
 
         """
-        return self._active_app_collater.get_collated_dataframe(self._active_app['id'])
+        return self._active_app_collater.get_collated_dataframe(self, self._active_app['id'])
 
     def apply_analysis(self, analysis):
         """Run the `analysis` element on the output of the last run collation.

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -279,8 +279,8 @@ class Campaign:
         campaign_db = self.campaign_db
         self.campaign_id = campaign_db.get_campaign_id(self.campaign_name)
 
-        # Resurrect the sampler and collation elements
-        self._active_sampler_id = campaign_db.get_sampler_id(self.campaign_id)
+        # Resurrect the sampler
+        sampler_id = campaign_db.get_sampler_id(self.campaign_id)
         self._active_sampler = campaign_db.resurrect_sampler(self._active_sampler_id)
 
         self.set_app(self._active_app_name)

--- a/easyvvuq/collate/aggregate_samples.py
+++ b/easyvvuq/collate/aggregate_samples.py
@@ -43,7 +43,7 @@ class AggregateSamples(BaseCollationElement, collater_name="aggregate_samples"):
 
         self.average = average
 
-    def collate(self, campaign):
+    def collate(self, campaign, app_id):
         """
         Collected the decoded run results for all completed runs with ENCODED status
 
@@ -93,16 +93,16 @@ class AggregateSamples(BaseCollationElement, collater_name="aggregate_samples"):
 
                 processed_run_IDs.append(run_id)
 
-        self.append_data(new_data)
+        self.append_data(new_data, app_id)
         campaign.campaign_db.set_run_statuses(processed_run_IDs, constants.Status.COLLATED)
 
         return len(processed_run_IDs)
 
-    def append_data(self, new_data):
-        self.campaign.campaign_db.append_collation_dataframe(new_data)
+    def append_data(self, new_data, app_id):
+        self.campaign.campaign_db.append_collation_dataframe(new_data, app_id)
 
-    def get_collated_dataframe(self):
-        return self.campaign.campaign_db.get_collation_dataframe()
+    def get_collated_dataframe(self, app_id):
+        return self.campaign.campaign_db.get_collation_dataframe(app_id)
 
     def element_version(self):
         return "0.1"

--- a/easyvvuq/collate/aggregate_samples.py
+++ b/easyvvuq/collate/aggregate_samples.py
@@ -58,7 +58,6 @@ class AggregateSamples(BaseCollationElement, collater_name="aggregate_samples"):
         `int`:
             The number of new data rows added during collation
         """
-        self.campaign = campaign
 
         decoder = campaign._active_app_decoder
 
@@ -70,7 +69,7 @@ class AggregateSamples(BaseCollationElement, collater_name="aggregate_samples"):
 
         # Loop through all runs with status ENCODED (and therefore not yet COLLATED)
         processed_run_IDs = []
-        for run_id, run_info in campaign.campaign_db.runs(status=constants.Status.ENCODED):
+        for run_id, run_info in campaign.campaign_db.runs(status=constants.Status.ENCODED, app_id=app_id):
 
             # Use decoder to check if run has completed (in general application-specific)
             if decoder.sim_complete(run_info=run_info):
@@ -93,16 +92,16 @@ class AggregateSamples(BaseCollationElement, collater_name="aggregate_samples"):
 
                 processed_run_IDs.append(run_id)
 
-        self.append_data(new_data, app_id)
+        self.append_data(campaign, new_data, app_id)
         campaign.campaign_db.set_run_statuses(processed_run_IDs, constants.Status.COLLATED)
 
         return len(processed_run_IDs)
 
-    def append_data(self, new_data, app_id):
-        self.campaign.campaign_db.append_collation_dataframe(new_data, app_id)
+    def append_data(self, campaign, new_data, app_id):
+        campaign.campaign_db.append_collation_dataframe(new_data, app_id)
 
-    def get_collated_dataframe(self, app_id):
-        return self.campaign.campaign_db.get_collation_dataframe(app_id)
+    def get_collated_dataframe(self, campaign, app_id):
+        return campaign.campaign_db.get_collation_dataframe(app_id)
 
     def element_version(self):
         return "0.1"

--- a/easyvvuq/collate/aggregate_samples.py
+++ b/easyvvuq/collate/aggregate_samples.py
@@ -69,7 +69,8 @@ class AggregateSamples(BaseCollationElement, collater_name="aggregate_samples"):
 
         # Loop through all runs with status ENCODED (and therefore not yet COLLATED)
         processed_run_IDs = []
-        for run_id, run_info in campaign.campaign_db.runs(status=constants.Status.ENCODED, app_id=app_id):
+        for run_id, run_info in campaign.campaign_db.runs(
+                status=constants.Status.ENCODED, app_id=app_id):
 
             # Use decoder to check if run has completed (in general application-specific)
             if decoder.sim_complete(run_info=run_info):

--- a/easyvvuq/collate/base.py
+++ b/easyvvuq/collate/base.py
@@ -44,7 +44,7 @@ class BaseCollationElement(BaseElement):
 
     def collate(self, campaign, app_id):
         """
-        Collates the campaign's decoded run output.
+        Collates the campaign's decoded run output for the specified app.
         Must be implemented by all collation subclasses.
         """
         raise NotImplementedError

--- a/easyvvuq/collate/base.py
+++ b/easyvvuq/collate/base.py
@@ -42,7 +42,7 @@ class BaseCollationElement(BaseElement):
 
     """
 
-    def collate(self, campaign):
+    def collate(self, campaign, app_id):
         """
         Collates the campaign's decoded run output.
         Must be implemented by all collation subclasses.
@@ -67,7 +67,7 @@ class BaseCollationElement(BaseElement):
         # Register new collater
         AVAILABLE_COLLATERS[collater_name] = cls
 
-    def get_collated_dataframe(self):
+    def get_collated_dataframe(self, app_id):
         """
         Returns collated data as a pandas dataframe
         """

--- a/easyvvuq/collate/base.py
+++ b/easyvvuq/collate/base.py
@@ -67,7 +67,7 @@ class BaseCollationElement(BaseElement):
         # Register new collater
         AVAILABLE_COLLATERS[collater_name] = cls
 
-    def get_collated_dataframe(self, app_id):
+    def get_collated_dataframe(self, campaign, app_id):
         """
         Returns collated data as a pandas dataframe
         """

--- a/easyvvuq/data_structs.py
+++ b/easyvvuq/data_structs.py
@@ -287,6 +287,11 @@ class AppInfo:
 
     @collater.setter
     def collater(self, collater):
+        if collater is None:
+            msg = "A 'collater' must be provided for this App (cannot be None)."
+            logging.error(msg)
+            raise Exception(msg)
+
         if not isinstance(collater, BaseCollationElement):
             msg = "Provided 'collater' must be derived from type BaseCollationElement"
             logging.error(msg)

--- a/easyvvuq/data_structs.py
+++ b/easyvvuq/data_structs.py
@@ -7,6 +7,7 @@ import json
 from easyvvuq import constants
 from easyvvuq.encoders import BaseEncoder
 from easyvvuq.decoders import BaseDecoder
+from easyvvuq.collate import BaseCollationElement
 
 __copyright__ = """
 
@@ -219,6 +220,8 @@ class AppInfo:
         Encoder element for application.
     decoder : :obj:`easyvvuq.decoders.base.BaseDecoder`
         Decoder element for application.
+    collater : :obj:`easyvvuq.collation.base.BaseCollationElement`
+        Collater element for application.
 
     Attributes
     ----------
@@ -232,6 +235,8 @@ class AppInfo:
         Encoder element for application.
     output_decoder : :obj:`easyvvuq.decoders.base.BaseDecoder`
         Decoder element for application.
+    collater : :obj:`easyvvuq.collation.base.BaseCollationElement`
+        Collater element for application.
     """
 
     def __init__(
@@ -240,11 +245,13 @@ class AppInfo:
             paramsspec=None,
             fixtures=None,
             encoder=None,
-            decoder=None):
+            decoder=None,
+            collater=None):
 
         self.name = name
         self.input_encoder = encoder
         self.output_decoder = decoder
+        self.collater = collater
         self.paramsspec = paramsspec
         self.fixtures = fixtures
 
@@ -273,6 +280,20 @@ class AppInfo:
             raise Exception(msg)
 
         self._output_decoder = decoder
+
+    @property
+    def collater(self):
+        return self._collater
+
+    @collater.setter
+    def collater(self, collater):
+        if not isinstance(collater, BaseCollationElement):
+            msg = "Provided 'collater' must be derived from type BaseCollationElement"
+            logging.error(msg)
+            raise Exception(msg)
+
+        self._collater = collater
+
 
     def to_dict(self, flatten=False):
         """Convert to a dictionary (optionally flatten to single level)
@@ -308,7 +329,8 @@ class AppInfo:
                 'params': self.paramsspec,
                 'fixtures': fixtures,
                 'input_encoder': self.input_encoder.serialize(),
-                'output_decoder': self.output_decoder.serialize()
+                'output_decoder': self.output_decoder.serialize(),
+                'collater': self.collater.serialize()
             }
 
         return out_dict

--- a/easyvvuq/data_structs.py
+++ b/easyvvuq/data_structs.py
@@ -178,7 +178,8 @@ class RunInfo:
         """
 
         def convert_nonserializable(obj):
-            if isinstance(obj, numpy.int64): return int(obj)
+            if isinstance(obj, numpy.int64):
+                return int(obj)
             raise TypeError('Unknown type:', type(obj))
 
         if flatten:

--- a/easyvvuq/data_structs.py
+++ b/easyvvuq/data_structs.py
@@ -401,7 +401,6 @@ class CampaignInfo:
             check_local_dir(runs_dir, 'runs')
 
         self.runs_dir = runs_dir
-        self.collater = None
 
     @property
     def easyvvuq_version(self):
@@ -431,8 +430,7 @@ class CampaignInfo:
             'campaign_dir': self.campaign_dir,
             'campaign_dir_prefix': self.campaign_dir_prefix,
             'runs_dir': self.runs_dir,
-            'easyvvuq_version': self.easyvvuq_version,
-            'collater': self.collater
+            'easyvvuq_version': self.easyvvuq_version
         }
 
         return out_dict

--- a/easyvvuq/data_structs.py
+++ b/easyvvuq/data_structs.py
@@ -8,6 +8,7 @@ from easyvvuq import constants
 from easyvvuq.encoders import BaseEncoder
 from easyvvuq.decoders import BaseDecoder
 from easyvvuq.collate import BaseCollationElement
+import numpy
 
 __copyright__ = """
 
@@ -176,13 +177,17 @@ class RunInfo:
             returned as a JSON format sting.
         """
 
+        def convert_nonserializable(obj):
+            if isinstance(obj, numpy.int64): return int(obj)
+            raise TypeError('Unknown type:', type(obj))
+
         if flatten:
 
             out_dict = {
                 'run_name': self.run_name,
                 'ensemble_name': self.ensemble_name,
                 'run_dir': self.run_dir,
-                'params': json.dumps(self.params),
+                'params': json.dumps(self.params, default=convert_nonserializable),
                 'status': constants.Status(self.status),
                 'campaign': self.campaign,
                 'sample': self.sample,

--- a/easyvvuq/data_structs.py
+++ b/easyvvuq/data_structs.py
@@ -299,7 +299,6 @@ class AppInfo:
 
         self._collater = collater
 
-
     def to_dict(self, flatten=False):
         """Convert to a dictionary (optionally flatten to single level)
 

--- a/easyvvuq/db/base.py
+++ b/easyvvuq/db/base.py
@@ -361,7 +361,7 @@ class BaseCampaignDB:
 
         raise NotImplementedError
 
-    def append_collation_dataframe(self, df):
+    def append_collation_dataframe(self, df, app_id):
         """
         Append the data in dataframe 'df' to that already collated in the database
 
@@ -369,6 +369,9 @@ class BaseCampaignDB:
         ----------
         df: pandas dataframe
             The dataframe whose contents need to be appended to the collation store
+        app_id: int
+            The id of this app in the sql database. Used to determine which collation
+            table is appended to.
 
         Returns
         -------
@@ -376,18 +379,22 @@ class BaseCampaignDB:
 
         raise NotImplementedError
 
-    def get_collation_dataframe(self):
+    def get_collation_dataframe(self, app_id):
         """
         Returns a dataframe containing the full collated results stored in this database
         i.e. the total of what was added with the append_collation_dataframe() method.
 
         Parameters
         ----------
+        app_id: int
+            The id of this app in the sql database. Used to determine which collation
+            table is returned.
 
         Returns
         -------
         df: pandas dataframe
-            The dataframe with all contents that were appended to this database
+            The dataframe with all contents that were appended to the table corresponding
+            to this app_id.
         """
 
         raise NotImplementedError

--- a/easyvvuq/db/base.py
+++ b/easyvvuq/db/base.py
@@ -133,44 +133,6 @@ class BaseCampaignDB:
 
         raise NotImplementedError
 
-    def set_campaign_collater(self, collater, campaign_id):
-        """
-        Store the state of the given collater object in the collation slot
-        for the campaign with id 'campaign_id'
-
-        Parameters
-        ----------
-        collater: BaseCollationElement
-            The collater object to serialize
-        campaign_id: int
-            The id of the campaign this collater should be assigned to
-
-        Returns
-        -------
-
-        """
-
-        raise NotImplementedError
-
-    def resurrect_collation(self, campaign_id):
-        """
-        Return the collater object corresponding to the campaign with id 'campaign_id'
-        in the database. It is deserialized from the state stored in the database.
-
-        Parameters
-        ----------
-        campaign_id: int
-            The id of the collater to resurrect
-
-        Returns
-        -------
-        BaseCollationElement
-            The 'live' collater object, deserialized from the state in the db
-
-        """
-
-        raise NotImplementedError
-
     def resurrect_app(self, app_name):
         """
         Return the 'live' encoder and decoder objects corresponding to the app with
@@ -184,7 +146,7 @@ class BaseCampaignDB:
 
         Returns
         -------
-        BaseEncoder, BaseDecoder
+        BaseEncoder, BaseDecoder, BaseCollationElement
             The 'live' encoder and decoder objects associated with this app
 
         """

--- a/easyvvuq/db/json.py
+++ b/easyvvuq/db/json.py
@@ -271,61 +271,6 @@ class CampaignDB(BaseCampaignDB):
         collater = BaseCollationElement.deserialize(self._app['collater'])
         return encoder, decoder, collater
 
-#    def set_campaign_collater(self, collater, campaign_id):
-#        """
-#        Store the state of the given collater object in the collation slot
-#        for the campaign with id 'campaign_id'
-#
-#        Parameters
-#        ----------
-#        collater: BaseCollationElement
-#            The collater object to serialize
-#        campaign_id: int
-#            The id of the campaign this collater should be assigned to
-#
-#        Returns
-#        -------
-#
-#        """
-#
-#        if campaign_id != 1:
-#            message = ('JSON/Python dict database does not support a '
-#                       'campaign_id other than 1')
-#            logger.critical(message)
-#            raise RuntimeError(message)
-#
-#        self._campaign_info['collater'] = collater.serialize()
-#
-#    def resurrect_collation(self, campaign_id):
-#        """
-#        Return the collater object corresponding to the campaign with id 'campaign_id'
-#        in the database. It is deserialized from the state stored in the database.
-#
-#        Parameters
-#        ----------
-#        campaign_id: int
-#            The id of the collater to resurrect
-#
-#        Returns
-#        -------
-#        BaseCollationElement
-#            The 'live' collater object, deserialized from the state in the db
-#
-#        """
-#
-#        if campaign_id != 1:
-#            message = ('JSON/Python dict database does not support a '
-#                       'campaign_id other than 1')
-#            logger.critical(message)
-#            raise RuntimeError(message)
-#
-#        if self._campaign_info['collater'] is None:
-#            print("Loaded campaign does not have a collation element currently set")
-#            return None
-#
-#        collater = BaseCollationElement.deserialize(self._campaign_info['collater'])
-#        return collater
-
     def add_runs(self, run_info_list=None, run_prefix='Run_', ensemble_prefix='Ensemble_'):
         """
         Add runs to the `runs` table in the database.

--- a/easyvvuq/db/json.py
+++ b/easyvvuq/db/json.py
@@ -250,8 +250,8 @@ class CampaignDB(BaseCampaignDB):
 
         Returns
         -------
-        BaseEncoder, BaseDecoder
-            The 'live' encoder and decoder objects associated with this app
+        BaseEncoder, BaseDecoder, BaseCollationElement
+            The 'live' encoder, decoder and collation objects associated with this app
 
         """
 
@@ -268,62 +268,63 @@ class CampaignDB(BaseCampaignDB):
 
         encoder = BaseEncoder.deserialize(self._app['input_encoder'])
         decoder = BaseDecoder.deserialize(self._app['output_decoder'])
-        return encoder, decoder
+        collater = BaseCollationElement.deserialize(self._app['collater'])
+        return encoder, decoder, collater
 
-    def set_campaign_collater(self, collater, campaign_id):
-        """
-        Store the state of the given collater object in the collation slot
-        for the campaign with id 'campaign_id'
-
-        Parameters
-        ----------
-        collater: BaseCollationElement
-            The collater object to serialize
-        campaign_id: int
-            The id of the campaign this collater should be assigned to
-
-        Returns
-        -------
-
-        """
-
-        if campaign_id != 1:
-            message = ('JSON/Python dict database does not support a '
-                       'campaign_id other than 1')
-            logger.critical(message)
-            raise RuntimeError(message)
-
-        self._campaign_info['collater'] = collater.serialize()
-
-    def resurrect_collation(self, campaign_id):
-        """
-        Return the collater object corresponding to the campaign with id 'campaign_id'
-        in the database. It is deserialized from the state stored in the database.
-
-        Parameters
-        ----------
-        campaign_id: int
-            The id of the collater to resurrect
-
-        Returns
-        -------
-        BaseCollationElement
-            The 'live' collater object, deserialized from the state in the db
-
-        """
-
-        if campaign_id != 1:
-            message = ('JSON/Python dict database does not support a '
-                       'campaign_id other than 1')
-            logger.critical(message)
-            raise RuntimeError(message)
-
-        if self._campaign_info['collater'] is None:
-            print("Loaded campaign does not have a collation element currently set")
-            return None
-
-        collater = BaseCollationElement.deserialize(self._campaign_info['collater'])
-        return collater
+#    def set_campaign_collater(self, collater, campaign_id):
+#        """
+#        Store the state of the given collater object in the collation slot
+#        for the campaign with id 'campaign_id'
+#
+#        Parameters
+#        ----------
+#        collater: BaseCollationElement
+#            The collater object to serialize
+#        campaign_id: int
+#            The id of the campaign this collater should be assigned to
+#
+#        Returns
+#        -------
+#
+#        """
+#
+#        if campaign_id != 1:
+#            message = ('JSON/Python dict database does not support a '
+#                       'campaign_id other than 1')
+#            logger.critical(message)
+#            raise RuntimeError(message)
+#
+#        self._campaign_info['collater'] = collater.serialize()
+#
+#    def resurrect_collation(self, campaign_id):
+#        """
+#        Return the collater object corresponding to the campaign with id 'campaign_id'
+#        in the database. It is deserialized from the state stored in the database.
+#
+#        Parameters
+#        ----------
+#        campaign_id: int
+#            The id of the collater to resurrect
+#
+#        Returns
+#        -------
+#        BaseCollationElement
+#            The 'live' collater object, deserialized from the state in the db
+#
+#        """
+#
+#        if campaign_id != 1:
+#            message = ('JSON/Python dict database does not support a '
+#                       'campaign_id other than 1')
+#            logger.critical(message)
+#            raise RuntimeError(message)
+#
+#        if self._campaign_info['collater'] is None:
+#            print("Loaded campaign does not have a collation element currently set")
+#            return None
+#
+#        collater = BaseCollationElement.deserialize(self._campaign_info['collater'])
+#        return collater
 
     def add_runs(self, run_info_list=None, run_prefix='Run_', ensemble_prefix='Ensemble_'):
         """

--- a/easyvvuq/db/json.py
+++ b/easyvvuq/db/json.py
@@ -158,7 +158,7 @@ class CampaignDB(BaseCampaignDB):
             raise RuntimeError(message)
 
         self._app = app_info.to_dict()
-        self._app['id'] = 0
+        self._app['id'] = 1
         self._save()
 
     def add_sampler(self, sampler):
@@ -598,7 +598,7 @@ class CampaignDB(BaseCampaignDB):
             self._runs[run_name]['status'] = status
         self._save()
 
-    def append_collation_dataframe(self, df):
+    def append_collation_dataframe(self, df, app_id):
         """
         Append the data in dataframe 'df' to that already collated in the database
 
@@ -611,12 +611,18 @@ class CampaignDB(BaseCampaignDB):
         -------
         """
 
+        if app_id != 1:
+            message = ('JSON/Python dict database does not support an '
+                       'app_id other than 1')
+            logger.critical(message)
+            raise RuntimeError(message)
+
         if os.path.exists(self._collation_csv):
             df.to_csv(self._collation_csv, mode='a', header=False)
         else:
             df.to_csv(self._collation_csv, mode='w', header=True)
 
-    def get_collation_dataframe(self):
+    def get_collation_dataframe(self, app_id):
         """
         Returns a dataframe containing the full collated results stored in this database
         i.e. the total of what was added with the append_collation_dataframe() method.
@@ -629,6 +635,12 @@ class CampaignDB(BaseCampaignDB):
         df: pandas dataframe
             The dataframe with all contents that were appended to this database
         """
+
+        if app_id != 1:
+            message = ('JSON/Python dict database does not support an '
+                       'app_id other than 1')
+            logger.critical(message)
+            raise RuntimeError(message)
 
         df = pd.read_csv(self._collation_csv)
         return df

--- a/easyvvuq/db/json.py
+++ b/easyvvuq/db/json.py
@@ -612,6 +612,9 @@ class CampaignDB(BaseCampaignDB):
         ----------
         df: pandas dataframe
             The dataframe whose contents need to be appended to the collation store
+        app_id: int
+            The id of the app in the sql database. Used to determine which collation
+            table is appended to.
 
         Returns
         -------
@@ -635,6 +638,9 @@ class CampaignDB(BaseCampaignDB):
 
         Parameters
         ----------
+        app_id: int
+            The id of the app in the sql database. Used to determine which collation
+            table is appended to.
 
         Returns
         -------

--- a/easyvvuq/db/json.py
+++ b/easyvvuq/db/json.py
@@ -390,7 +390,7 @@ class CampaignDB(BaseCampaignDB):
 
         return self._campaign_info['campaign_dir']
 
-    def runs(self, campaign=None, sampler=None, status=None, not_status=None):
+    def runs(self, campaign=None, sampler=None, status=None, not_status=None, app_id=1):
         """
         A generator to return all run information for selected `campaign` and `sampler`.
 
@@ -417,6 +417,12 @@ class CampaignDB(BaseCampaignDB):
                        f'single campaign and sampler workflows - ignoring'
                        f'campaign - {campaign}/ sampler {sampler}')
             logger.warning(message)
+
+        if app_id != 1:
+            message = ('JSON/Python dict database does not support an '
+                       'app_id other than 1')
+            logger.critical(message)
+            raise RuntimeError(message)
 
         for run_id, run_info in self._runs.items():
             if (status is None or run_info['status'] ==

--- a/easyvvuq/db/sql.py
+++ b/easyvvuq/db/sql.py
@@ -612,7 +612,7 @@ class CampaignDB(BaseCampaignDB):
 
         return self._get_campaign_info(campaign_name=campaign_name).campaign_dir
 
-    def _select_runs(self, name=None, campaign=None, sampler=None, status=None, not_status=None):
+    def _select_runs(self, name=None, campaign=None, sampler=None, status=None, not_status=None, app_id=None):
         """
         Select all runs in the database which match the input criteria.
 
@@ -643,6 +643,8 @@ class CampaignDB(BaseCampaignDB):
             filter_options['sampler'] = sampler
         if status:
             filter_options['status'] = status
+        if app_id:
+            filter_options['app'] = app_id
 
         # Note that for some databases this can be sped up with a yield_per(), but not all
         selected = self.session.query(RunTable).filter_by(
@@ -650,7 +652,7 @@ class CampaignDB(BaseCampaignDB):
 
         return selected
 
-    def run(self, name, campaign=None, sampler=None, status=None, not_status=None):
+    def run(self, name, campaign=None, sampler=None, status=None, not_status=None, app_id=None):
         """
         Get the information for a specified run.
 
@@ -679,7 +681,8 @@ class CampaignDB(BaseCampaignDB):
             campaign=campaign,
             sampler=sampler,
             status=status,
-            not_status=not_status)
+            not_status=not_status,
+            app_id=app_id)
 
         if selected.count() != 1:
             logging.warning('Multiple runs selected - using the first')
@@ -688,7 +691,7 @@ class CampaignDB(BaseCampaignDB):
 
         return self._run_to_dict(selected)
 
-    def runs(self, campaign=None, sampler=None, status=None, not_status=None):
+    def runs(self, campaign=None, sampler=None, status=None, not_status=None, app_id=None):
         """
         A generator to return all run information for selected `campaign` and `sampler`.
 
@@ -715,7 +718,8 @@ class CampaignDB(BaseCampaignDB):
             campaign=campaign,
             sampler=sampler,
             status=status,
-            not_status=not_status)
+            not_status=not_status,
+            app_id=app_id)
 
         for r in selected:
             yield r.run_name, self._run_to_dict(r)

--- a/easyvvuq/db/sql.py
+++ b/easyvvuq/db/sql.py
@@ -292,51 +292,6 @@ class CampaignDB(BaseCampaignDB):
         sampler = BaseSamplingElement.deserialize(serialized_sampler)
         return sampler
 
-#    def set_campaign_collater(self, collater, campaign_id):
-#        """
-#        Store the state of the given collater object in the collation slot
-#        for the campaign with id 'campaign_id'
-#
-#        Parameters
-#        ----------
-#        collater: BaseCollationElement
-#            The collater object to serialize
-#        campaign_id: int
-#            The id of the campaign this collater should be assigned to
-#
-#        Returns
-#        -------
-#
-#        """
-#
-#        selected = self.session.query(CampaignTable).get(campaign_id)
-#        selected.collater = collater.serialize()
-#        self.session.commit()
-
-#    def resurrect_collation(self, campaign_id):
-#        """
-#        Return the collater object corresponding to the campaign with id 'campaign_id'
-#        in the database. It is deserialized from the state stored in the database.
-#
-#        Parameters
-#        ----------
-#        campaign_id: int
-#            The id of the collater to resurrect
-#
-#        Returns
-#        -------
-#        BaseCollationElement
-#            The 'live' collater object, deserialized from the state in the db
-#
-#        """
-#
-#        serialized_collater = self.session.query(CampaignTable).get(campaign_id).collater
-#        if serialized_collater is None:
-#            print("Loaded campaign does not have a collation element currently set")
-#            return None
-#        collater = BaseCollationElement.deserialize(serialized_collater)
-#        return collater
-
     def resurrect_app(self, app_name):
         """
         Return the 'live' encoder, decoder and collation objects corresponding to the app with

--- a/easyvvuq/db/sql.py
+++ b/easyvvuq/db/sql.py
@@ -612,7 +612,14 @@ class CampaignDB(BaseCampaignDB):
 
         return self._get_campaign_info(campaign_name=campaign_name).campaign_dir
 
-    def _select_runs(self, name=None, campaign=None, sampler=None, status=None, not_status=None, app_id=None):
+    def _select_runs(
+            self,
+            name=None,
+            campaign=None,
+            sampler=None,
+            status=None,
+            not_status=None,
+            app_id=None):
         """
         Select all runs in the database which match the input criteria.
 

--- a/easyvvuq/db/sql.py
+++ b/easyvvuq/db/sql.py
@@ -767,9 +767,10 @@ class CampaignDB(BaseCampaignDB):
 
         return self._get_campaign_info(campaign_name=campaign_name).runs_dir
 
-    def append_collation_dataframe(self, df):
+    def append_collation_dataframe(self, df, app_id):
         """
         Append the data in dataframe 'df' to that already collated in the database
+        for the specified app.
 
         Parameters
         ----------
@@ -780,11 +781,13 @@ class CampaignDB(BaseCampaignDB):
         -------
         """
 
-        df.to_sql("COLLATIONRESULT", self.engine, if_exists='append')
+        tablename = 'COLLATION_APP' + str(app_id)
+        df.to_sql(tablename, self.engine, if_exists='append')
 
-    def get_collation_dataframe(self):
+    def get_collation_dataframe(self, app_id):
         """
         Returns a dataframe containing the full collated results stored in this database
+        for the specified app.
         i.e. the total of what was added with the append_collation_dataframe() method.
 
         Parameters
@@ -796,6 +799,7 @@ class CampaignDB(BaseCampaignDB):
             The dataframe with all contents that were appended to this database
         """
 
-        query = "select * from COLLATIONRESULT"
+        tablename = 'COLLATION_APP' + str(app_id)
+        query = "select * from " + tablename
         df = pd.read_sql_query(query, self.engine)
         return df

--- a/easyvvuq/db/sql.py
+++ b/easyvvuq/db/sql.py
@@ -787,6 +787,9 @@ class CampaignDB(BaseCampaignDB):
         ----------
         df: pandas dataframe
             The dataframe whose contents need to be appended to the collation store
+        app_id: int
+            The id of the app in the sql database. Used to determine which collation
+            table is appended to.
 
         Returns
         -------
@@ -803,6 +806,9 @@ class CampaignDB(BaseCampaignDB):
 
         Parameters
         ----------
+        app_id: int
+            The id of the app in the sql database. Used to determine which collation
+            table is appended to.
 
         Returns
         -------

--- a/easyvvuq/distributions/distributions.py
+++ b/easyvvuq/distributions/distributions.py
@@ -97,7 +97,7 @@ class uniform_integer(Dist):
             Random samples with shape ``size``.
         """
 
-        return [int(i) for i in np.random.randint(self.lo, self.up, size)]
+        return np.random.randint(self.lo, self.up, size)
 
 
 # TODO: Convert this to a chaospy style distribution

--- a/easyvvuq/params_specification.py
+++ b/easyvvuq/params_specification.py
@@ -4,6 +4,7 @@
 import logging
 import cerberus
 import json
+import numpy
 
 __copyright__ = """
 
@@ -33,6 +34,9 @@ logger = logging.getLogger(__name__)
 class EasyVVUQValidator(cerberus.Validator):
     def __init__(self, *args, **kwargs):
         super(EasyVVUQValidator, self).__init__(*args, **kwargs)
+
+        integer_type = cerberus.TypeDefinition('integer', (int,numpy.int64), ())
+        cerberus.Validator.types_mapping['integer'] = integer_type
 
     def _validate_type_fixture(self, value):
         # Fixtures type not validated at present

--- a/easyvvuq/params_specification.py
+++ b/easyvvuq/params_specification.py
@@ -35,13 +35,13 @@ class EasyVVUQValidator(cerberus.Validator):
     def __init__(self, *args, **kwargs):
         super(EasyVVUQValidator, self).__init__(*args, **kwargs)
 
+        # Add numpy.int64 as an acceptable 'integer' type
         integer_type = cerberus.TypeDefinition('integer', (int,numpy.int64), ())
         cerberus.Validator.types_mapping['integer'] = integer_type
 
-    def _validate_type_fixture(self, value):
-        # Fixtures type not validated at present
-        return True
-
+        # Add 'fixture' type (for now, it's expected just to be a string)
+        fixture_type = cerberus.TypeDefinition('fixture', (str), ())
+        cerberus.Validator.types_mapping['fixture'] = fixture_type
 
 class ParamsSpecification:
 

--- a/easyvvuq/params_specification.py
+++ b/easyvvuq/params_specification.py
@@ -36,12 +36,13 @@ class EasyVVUQValidator(cerberus.Validator):
         super(EasyVVUQValidator, self).__init__(*args, **kwargs)
 
         # Add numpy.int64 as an acceptable 'integer' type
-        integer_type = cerberus.TypeDefinition('integer', (int,numpy.int64), ())
+        integer_type = cerberus.TypeDefinition('integer', (int, numpy.int64), ())
         cerberus.Validator.types_mapping['integer'] = integer_type
 
         # Add 'fixture' type (for now, it's expected just to be a string)
         fixture_type = cerberus.TypeDefinition('fixture', (str), ())
         cerberus.Validator.types_mapping['fixture'] = fixture_type
+
 
 class ParamsSpecification:
 

--- a/easyvvuq/worker.py
+++ b/easyvvuq/worker.py
@@ -70,7 +70,8 @@ class Worker:
         self._active_app_name = app_name
         self._active_app = self.campaign_db.app(name=app_name)
         (self._active_app_encoder,
-         self._active_app_decoder) = self.campaign_db.resurrect_app(app_name)
+         self._active_app_decoder,
+         self._active_app_collater) = self.campaign_db.resurrect_app(app_name)
 
     def encode_runs(self, run_id_list):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 pep8ignore =
 	*.py E265
 	__init__.py E402
+    tests/*.py E128
 pep8maxlinelength=100
 
 [versioneer]

--- a/tests/cannonsim/src/cannonsim.cc
+++ b/tests/cannonsim/src/cannonsim.cc
@@ -1,7 +1,7 @@
 /**
- * Copyright 2018 Robin A. Richardson, David W. Wright 
+ * Copyright 2018 Robin A. Richardson, David W. Wright
  *
- * This file is part of EasyVVUQ 
+ * This file is part of EasyVVUQ
  *
  * EasyVVUQ is free software: you can redistribute it and/or modify
  * it under the terms of the Lesser GNU General Public License as published by
@@ -12,7 +12,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * Lesser GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the Lesser GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
 
 	double g, m, v0, theta, h0, nu, dt;
 	std::string header, param, equals;
-	
+
 	// Check for correct header
 	infile >> header;
 	fail_if_not(header, "CANONSIM_INPUT_FILE:");
@@ -86,8 +86,6 @@ int main(int argc, char **argv)
 	infile >> param >> equals >> dt;    fail_if_not(equals, "="); fail_if_not(param, "time_step"); param="";
 
 	infile.close();
-
-	//std::cout << header << " " << param << " " << equals << " " << g << " " << m << " " << v0 << " " << theta << " " << h0 << " " << nu << " " << dt << "\n";
 
 	// Run sim
 	double out_dist, out_vx, out_vy;

--- a/tests/cannonsim/src/cannonsim.cc
+++ b/tests/cannonsim/src/cannonsim.cc
@@ -36,7 +36,6 @@ void launch(double g, double m, double v0, double theta, double h0, double nu, d
 		vy -= vy * nu * dt;
 		x += vx * dt;
 		y += vy * dt;
-		//std::cout << "pos: " << x << " " << y << " vel: " << vx << " " << vy << "\n";
 	}
 
 	out_dist = x;

--- a/tests/sc/sparse_sc_test.py
+++ b/tests/sc/sparse_sc_test.py
@@ -48,16 +48,14 @@ encoder = uq.encoders.GenericEncoder(
 decoder = uq.decoders.SimpleCSV(target_filename=output_filename,
                                 output_columns=output_columns,
                                 header=0)
-
-# Create a collation element for this campaign
 collater = uq.collate.AggregateSamples(average=False)
-my_campaign.set_collater(collater)
 
 # Add the SC app (automatically set as current app)
 my_campaign.add_app(name="sc",
                     params=params,
                     encoder=encoder,
-                    decoder=decoder)
+                    decoder=decoder,
+                    collater=collater)
 
 # Create the sampler
 vary = {

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -36,7 +36,9 @@ def app_info():
         uq.decoders.SimpleCSV(
             target_filename='output.csv',
             output_columns=["te", "ti"],
-            header=0))
+            header=0),
+        uq.collate.AggregateSamples(average=False))
+
     return app_info
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -66,15 +66,15 @@ def campaign():
         my_campaign = uq.Campaign(name=campaign_name, work_dir=work_dir, db_type=db_type)
         logging.debug("Serialized encoder:", encoder.serialize())
         logging.debug("Serialized decoder:", decoder.serialize())
+        logging.debug("Serialized collation:", collater.serialize())
         # Add the cannonsim app
         my_campaign.add_app(name=app_name,
                             params=params,
                             encoder=encoder,
                             decoder=decoder,
+                            collater=collater,
                             fixtures=fixtures)
         my_campaign.set_app(app_name)
-        my_campaign.set_collater(collater)
-        logging.debug("Serialized collation:", collater.serialize())
         logging.debug("Serialized sampler:", sampler.serialize())
         # Set the campaign to use this sampler
         my_campaign.set_sampler(sampler)

--- a/tests/test_multiapp.py
+++ b/tests/test_multiapp.py
@@ -145,8 +145,8 @@ def test_multiapp(tmpdir):
     my_campaign = uq.Campaign(name='multiapp', work_dir=tmpdir)
 
     # Add the cannonsim app to the campaign
-    (params, encoder, decoder, collater,
-    cannon_sampler, cannon_action, cannon_stats) = setup_cannonsim_app()
+    (params, encoder, decoder, collater, cannon_sampler,
+     cannon_action, cannon_stats) = setup_cannonsim_app()
     my_campaign.add_app(name="cannonsim",
                         params=params,
                         encoder=encoder,
@@ -158,7 +158,7 @@ def test_multiapp(tmpdir):
 
     # Add the cooling app to the campaign
     (params, encoder, decoder, collater, cooling_sampler,
-    cooling_action, cooling_stats) = setup_cooling_app()
+     cooling_action, cooling_stats) = setup_cooling_app()
     my_campaign.add_app(name="cooling",
                         params=params,
                         encoder=encoder,

--- a/tests/test_multiapp.py
+++ b/tests/test_multiapp.py
@@ -38,6 +38,7 @@ if not os.path.exists("tests/cannonsim/bin/cannonsim"):
 
 CANNONSIM_PATH = os.path.realpath(os.path.expanduser("tests/cannonsim/bin/cannonsim"))
 
+
 def setup_cannonsim_app():
     params = {
         "angle": {
@@ -138,6 +139,7 @@ def setup_cooling_app():
 
     return params, encoder, decoder, collater, cooling_sampler, cooling_action, cooling_stats
 
+
 def test_multiapp(tmpdir):
 
     my_campaign = uq.Campaign(name='multiapp', work_dir=tmpdir)
@@ -175,7 +177,6 @@ def test_multiapp(tmpdir):
     print("List of runs added:")
     pprint(my_campaign.list_runs())
     print("---")
-
 
     # Populate the runs dirs for runs belonging to the cannonsim app
     my_campaign.set_app("cannonsim")

--- a/tests/test_multiapp.py
+++ b/tests/test_multiapp.py
@@ -213,10 +213,15 @@ def test_multiapp(tmpdir):
     my_campaign.set_app("cooling")
     print("cooling data:", my_campaign.get_collation_result())
 
-    sys.exit(0)
+    # Apply analysis for cannon app
+    my_campaign.set_app("cannonsim")
+    my_campaign.apply_analysis(cannon_stats)
+    print("cannon stats:\n", my_campaign.get_last_analysis())
 
-    my_campaign.apply_analysis(stats)
-    print("stats:\n", my_campaign.get_last_analysis())
+    # Apply analysis for cooling app
+    my_campaign.set_app("cooling")
+    my_campaign.apply_analysis(cooling_stats)
+    print("cooling stats:\n", my_campaign.get_last_analysis())
 
     # Print the campaign log
     pprint(my_campaign._log)

--- a/tests/test_multiapp.py
+++ b/tests/test_multiapp.py
@@ -145,7 +145,8 @@ def test_multiapp(tmpdir):
     my_campaign = uq.Campaign(name='multiapp', work_dir=tmpdir)
 
     # Add the cannonsim app to the campaign
-    params, encoder, decoder, collater, cannon_sampler, cannon_action, cannon_stats = setup_cannonsim_app()
+    (params, encoder, decoder, collater,
+    cannon_sampler, cannon_action, cannon_stats) = setup_cannonsim_app()
     my_campaign.add_app(name="cannonsim",
                         params=params,
                         encoder=encoder,
@@ -156,7 +157,8 @@ def test_multiapp(tmpdir):
     my_campaign.set_sampler(cannon_sampler)
 
     # Add the cooling app to the campaign
-    params, encoder, decoder, collater, cooling_sampler, cooling_action, cooling_stats = setup_cooling_app()
+    (params, encoder, decoder, collater, cooling_sampler,
+    cooling_action, cooling_stats) = setup_cooling_app()
     my_campaign.add_app(name="cooling",
                         params=params,
                         encoder=encoder,

--- a/tests/test_multiapp.py
+++ b/tests/test_multiapp.py
@@ -176,18 +176,44 @@ def test_multiapp(tmpdir):
     pprint(my_campaign.list_runs())
     print("---")
 
+
+    # Populate the runs dirs for runs belonging to the cannonsim app
+    my_campaign.set_app("cannonsim")
     my_campaign.populate_runs_dir()
 
-    sys.exit(0)
+    # Populate the runs dirs for runs belonging to the cooling app
+    my_campaign.set_app("cooling")
+    my_campaign.populate_runs_dir()
 
-    my_campaign.apply_for_each_run_dir(
-        uq.actions.ExecuteLocal("tests/cannonsim/bin/cannonsim in.cannon output.csv"))
+    # Execute all the cannon runs
+    my_campaign.set_app("cannonsim")
+    my_campaign.apply_for_each_run_dir(cannon_action)
+
+    # Execute all the cooling runs
+    my_campaign.set_app("cooling")
+    my_campaign.apply_for_each_run_dir(cooling_action)
 
     print("Runs list after encoding and execution:")
     pprint(my_campaign.list_runs())
 
+    # Collate cannon results
+    my_campaign.set_app("cannonsim")
     my_campaign.collate()
-    print("data:", my_campaign.get_collation_result())
+
+    # Collate cooling results
+    my_campaign.set_app("cooling")
+    my_campaign.collate()
+
+    print("Runs list after collation:")
+    pprint(my_campaign.list_runs())
+
+    my_campaign.set_app("cannonsim")
+    print("cannonsim data:", my_campaign.get_collation_result())
+
+    my_campaign.set_app("cooling")
+    print("cooling data:", my_campaign.get_collation_result())
+
+    sys.exit(0)
 
     my_campaign.apply_analysis(stats)
     print("stats:\n", my_campaign.get_last_analysis())

--- a/tests/test_multiapp.py
+++ b/tests/test_multiapp.py
@@ -1,0 +1,202 @@
+import easyvvuq as uq
+import chaospy as cp
+import os
+import sys
+import pytest
+from pprint import pprint
+import subprocess
+
+__copyright__ = """
+
+    Copyright 2018 Robin A. Richardson, David W. Wright
+
+    This file is part of EasyVVUQ
+
+    EasyVVUQ is free software: you can redistribute it and/or modify
+    it under the terms of the Lesser GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    EasyVVUQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    Lesser GNU General Public License for more details.
+
+    You should have received a copy of the Lesser GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+__license__ = "LGPL"
+
+
+# If cannonsim has not been built (to do so, run the Makefile in tests/cannonsim/src/)
+# then skip this test
+if not os.path.exists("tests/cannonsim/bin/cannonsim"):
+    pytest.skip(
+        "Skipping cannonsim test (cannonsim is not installed in tests/cannonsim/bin/)",
+        allow_module_level=True)
+
+CANNONSIM_PATH = os.path.realpath(os.path.expanduser("tests/cannonsim/bin/cannonsim"))
+
+def setup_cannonsim_app():
+    params = {
+        "angle": {
+            "type": "float",
+            "min": 0.0,
+            "max": 6.28,
+            "default": 0.79},
+        "air_resistance": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1.0,
+            "default": 0.2},
+        "height": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1000.0,
+            "default": 1.0},
+        "time_step": {
+            "type": "float",
+            "min": 0.0001,
+            "max": 1.0,
+            "default": 0.01},
+        "gravity": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1000.0,
+            "default": 9.8},
+        "mass": {
+            "type": "float",
+            "min": 0.0001,
+            "max": 1000.0,
+            "default": 1.0},
+        "velocity": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1000.0,
+            "default": 10.0}}
+
+    encoder = uq.encoders.GenericEncoder(
+        template_fname='tests/cannonsim/test_input/cannonsim.template',
+        delimiter='#',
+        target_filename='in.cannon')
+    decoder = uq.decoders.SimpleCSV(
+        target_filename='output.csv', output_columns=[
+            'Dist', 'lastvx', 'lastvy'], header=0)
+    collater = uq.collate.AggregateSamples(average=False)
+
+    vary = {
+        "gravity": cp.Uniform(9.8, 1.0),
+        "mass": cp.Uniform(2.0, 10.0),
+    }
+    cannon_sampler = uq.sampling.RandomSampler(vary=vary, max_num=5)
+    cannon_action = uq.actions.ExecuteLocal("tests/cannonsim/bin/cannonsim in.cannon output.csv")
+    cannon_stats = uq.analysis.BasicStats(qoi_cols=['Dist', 'lastvx', 'lastvy'])
+
+    return params, encoder, decoder, collater, cannon_sampler, cannon_action, cannon_stats
+
+
+def setup_cooling_app():
+    params = {
+        "temp_init": {
+            "type": "float",
+            "min": 0.0,
+            "max": 100.0,
+            "default": 95.0},
+        "kappa": {
+            "type": "float",
+            "min": 0.0,
+            "max": 0.1,
+            "default": 0.025},
+        "t_env": {
+            "type": "float",
+            "min": 0.0,
+            "max": 40.0,
+            "default": 15.0},
+        "out_file": {
+            "type": "string",
+            "default": "output.csv"}}
+    output_filename = params["out_file"]["default"]
+    output_columns = ["te", "ti"]
+
+    encoder = uq.encoders.GenericEncoder(
+        template_fname='tests/cooling/cooling.template',
+        delimiter='$',
+        target_filename='cooling_in.json')
+    decoder = uq.decoders.SimpleCSV(target_filename=output_filename,
+                                    output_columns=output_columns,
+                                    header=0)
+    collater = uq.collate.AggregateSamples(average=False)
+
+    vary = {
+        "kappa": cp.Uniform(0.025, 0.075),
+        "t_env": cp.Uniform(15, 25)
+    }
+    cooling_sampler = uq.sampling.PCESampler(vary=vary, polynomial_order=3)
+    cooling_action = uq.actions.ExecuteLocal("tests/cooling/cooling_model.py cooling_in.json")
+    cooling_stats = uq.analysis.PCEAnalysis(sampler=cooling_sampler, qoi_cols=output_columns)
+
+    return params, encoder, decoder, collater, cooling_sampler, cooling_action, cooling_stats
+
+def test_multiapp(tmpdir):
+
+    my_campaign = uq.Campaign(name='multiapp', work_dir=tmpdir)
+
+    # Add the cannonsim app to the campaign
+    params, encoder, decoder, collater, cannon_sampler, cannon_action, cannon_stats = setup_cannonsim_app()
+    my_campaign.add_app(name="cannonsim",
+                        params=params,
+                        encoder=encoder,
+                        decoder=decoder,
+                        collater=collater)
+
+    my_campaign.set_app("cannonsim")
+    my_campaign.set_sampler(cannon_sampler)
+
+    # Add the cooling app to the campaign
+    params, encoder, decoder, collater, cooling_sampler, cooling_action, cooling_stats = setup_cooling_app()
+    my_campaign.add_app(name="cooling",
+                        params=params,
+                        encoder=encoder,
+                        decoder=decoder,
+                        collater=collater)
+
+    # Set campaign to cannonsim, apply sampler, draw all samples
+    my_campaign.set_app("cannonsim")
+    my_campaign.set_sampler(cannon_sampler)
+    my_campaign.draw_samples()
+
+    # Set campaign to cooling model, apply sampler, draw all samples
+    my_campaign.set_app("cooling")
+    my_campaign.set_sampler(cooling_sampler)
+    my_campaign.draw_samples()
+
+    # Print the list of runs now in the campaign db
+    print("List of runs added:")
+    pprint(my_campaign.list_runs())
+    print("---")
+
+    sys.exit(0)
+
+    # Encode and execute.
+    my_campaign.populate_runs_dir()
+    my_campaign.apply_for_each_run_dir(
+        uq.actions.ExecuteLocal("tests/cannonsim/bin/cannonsim in.cannon output.csv"))
+
+    print("Runs list after encoding and execution:")
+    pprint(my_campaign.list_runs())
+
+    my_campaign.collate()
+    print("data:", my_campaign.get_collation_result())
+
+    my_campaign.apply_analysis(stats)
+    print("stats:\n", my_campaign.get_last_analysis())
+
+    # Print the campaign log
+    pprint(my_campaign._log)
+
+    print("All completed?", my_campaign.all_complete())
+
+
+if __name__ == "__main__":
+    test_multiapp("/tmp/")

--- a/tests/test_multiapp.py
+++ b/tests/test_multiapp.py
@@ -176,10 +176,10 @@ def test_multiapp(tmpdir):
     pprint(my_campaign.list_runs())
     print("---")
 
+    my_campaign.populate_runs_dir()
+
     sys.exit(0)
 
-    # Encode and execute.
-    my_campaign.populate_runs_dir()
     my_campaign.apply_for_each_run_dir(
         uq.actions.ExecuteLocal("tests/cannonsim/bin/cannonsim in.cannon output.csv"))
 

--- a/tests/test_multisampler.py
+++ b/tests/test_multisampler.py
@@ -82,7 +82,7 @@ def test_worker(tmpdir):
             "max": 1000.0,
             "default": 10.0}}
 
-    # Create an encoder and decoder for the cannonsim app
+    # Create an encoder, decoder and collater for the cannonsim app
     encoder = uq.encoders.GenericEncoder(
         template_fname='tests/cannonsim/test_input/cannonsim.template',
         delimiter='#',
@@ -90,20 +90,19 @@ def test_worker(tmpdir):
     decoder = uq.decoders.SimpleCSV(
         target_filename='output.csv', output_columns=[
             'Dist', 'lastvx', 'lastvy'], header=0)
+    collater = uq.collate.AggregateSamples(average=False)
 
     # Add the cannonsim app
     my_campaign.add_app(name="cannonsim",
                         params=params,
                         encoder=encoder,
-                        decoder=decoder)
+                        decoder=decoder,
+                        collater=collater)
 
     # Set the active app to be cannonsim (this is redundant when only one app
     # has been added)
     my_campaign.set_app("cannonsim")
 
-    # Create a collation element for this campaign
-    collater = uq.collate.AggregateSamples(average=False)
-    my_campaign.set_collater(collater)
 
     # Set up samplers
     sweep1 = {

--- a/tests/test_multisampler.py
+++ b/tests/test_multisampler.py
@@ -39,7 +39,7 @@ if not os.path.exists("tests/cannonsim/bin/cannonsim"):
 CANNONSIM_PATH = os.path.realpath(os.path.expanduser("tests/cannonsim/bin/cannonsim"))
 
 
-def test_worker(tmpdir):
+def test_multisampler(tmpdir):
 
     # Set up a fresh campaign called "cannon"
     my_campaign = uq.Campaign(name='cannon', work_dir=tmpdir)
@@ -164,4 +164,4 @@ def test_worker(tmpdir):
 
 
 if __name__ == "__main__":
-    test_worker("/tmp/")
+    test_multisampler("/tmp/")

--- a/tests/test_multisampler.py
+++ b/tests/test_multisampler.py
@@ -103,7 +103,6 @@ def test_worker(tmpdir):
     # has been added)
     my_campaign.set_app("cannonsim")
 
-
     # Set up samplers
     sweep1 = {
         "angle": [0.1, 0.2, 0.3],

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -39,14 +39,14 @@ def restart(tmpdir):
     encoder = uq.encoders.GenericEncoder(template_fname='tests/gauss/gauss.template',
                                          target_filename='gauss_in.json')
     decoder = GaussDecoder(target_filename=params['out_file']['default'])
+    collater = uq.collate.AggregateSamples(average=False)
     my_campaign.add_app(name='gauss',
                         params=params,
                         encoder=encoder,
                         decoder=decoder,
+                        collater=collater,
                         fixtures=None)
     my_campaign.set_app('gauss')
-    collater = uq.collate.AggregateSamples(average=False)
-    my_campaign.set_collater(collater)
     vary = {
         "mu": cp.Uniform(1.0, 100.0),
     }

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -57,10 +57,10 @@ def test_worker(tmpdir):
             "max": 1.0,
             "default": 0.2},
         "height": {
-            "type": "float",
-            "min": 0.0,
-            "max": 1000.0,
-            "default": 1.0},
+            "type": "integer",
+            "min": 0,
+            "max": 1000,
+            "default": 1},
         "time_step": {
             "type": "float",
             "min": 0.0001,
@@ -106,7 +106,7 @@ def test_worker(tmpdir):
     # Make a random sampler
     vary = {
         "angle": cp.Uniform(0.0, 1.0),
-        "height": cp.Uniform(2.0, 10.0),
+        "height": uq.distributions.uniform_integer(0, 100),
         "velocity": cp.Normal(10.0, 1.0),
         "mass": cp.Uniform(5.0, 1.0)
     }

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -82,7 +82,7 @@ def test_worker(tmpdir):
             "max": 1000.0,
             "default": 10.0}}
 
-    # Create an encoder and decoder for the cannonsim app
+    # Create an encoder, decoder and collater for the cannonsim app
     encoder = uq.encoders.GenericEncoder(
         template_fname='tests/cannonsim/test_input/cannonsim.template',
         delimiter='#',
@@ -90,21 +90,18 @@ def test_worker(tmpdir):
     decoder = uq.decoders.SimpleCSV(
         target_filename='output.csv', output_columns=[
             'Dist', 'lastvx', 'lastvy'], header=0)
+    collater = uq.collate.AggregateSamples(average=False)
 
     # Add the cannonsim app
     my_campaign.add_app(name="cannonsim",
                         params=params,
                         encoder=encoder,
-                        decoder=decoder)
+                        decoder=decoder,
+                        collater=collater)
 
     # Set the active app to be cannonsim (this is redundant when only one app
     # has been added)
     my_campaign.set_app("cannonsim")
-
-    # Create a collation element for this campaign
-    collater = uq.collate.AggregateSamples(average=False)
-    my_campaign.set_collater(collater)
-    print("Serialized collation:", collater.serialize())
 
     # Make a random sampler
     vary = {


### PR DESCRIPTION
In order to support multi-app workflows, it was necessary to make the collation elements a property of each app, rather than having a single collater for the whole campaign. This was largely to do with mismatching output from the decoders meaning a single table in the sql database could not be used to aggregate all results across all apps. Also, it would be extremely confusing and messy to mix results like that anyway, not least with respect to the function of the analysis elements.

I have implemented this change, and updated the tests and tutorials as needed. From the perspective of the users, the only change is that a collater is now added via the ```add_app()```, and the ```set_collater()``` method no longer exists.