### PR TITLE
Use DiscreteUniform distribution from chaospy

### DIFF
--- a/easyvvuq/distributions/__init__.py
+++ b/easyvvuq/distributions/__init__.py
@@ -1,5 +1,3 @@
-from .distributions import uniform_integer
-
 __copyright__ = """
 
     Copyright 2018 Robin A. Richardson, David W. Wright

--- a/easyvvuq/distributions/distributions.py
+++ b/easyvvuq/distributions/distributions.py
@@ -1,6 +1,5 @@
 import numpy as np
 import csv
-from chaospy import Dist
 
 __copyright__ = """
 

--- a/easyvvuq/distributions/distributions.py
+++ b/easyvvuq/distributions/distributions.py
@@ -45,61 +45,6 @@ def options(choices):
             yield choice
 
 
-# A discrete distribution (integers only) for use with random seeds.
-class uniform_integer(Dist):
-    def __init__(self, lo, up):
-        """
-        Initializer.
-        """
-        Dist.__init__(self, lo=lo, up=up)
-        self.lo = lo
-        self.up = up
-
-    def cdf(self, x_data):
-        """
-        Cumulative distribution function.
-        """
-        return (x_data - self.lo) / (self.up - self.lo)
-
-    def bnd(self):
-        """
-        Lower and upper bounds.
-        """
-
-        return self.lo, self.up
-
-    def pdf(self, step=1e-07):
-        """
-        Probability density function.
-        """
-        return 1. / (self.up - self.lo)
-
-    def ppf(self, q_data):
-        """
-        Point percentile function.
-        """
-        return q_data * (self.up - self.lo) + self.lo
-
-    def sample(self, size=()):
-        """
-        Produces random integer values i, uniformly distributed on the closed
-        interval [lo, up], that is, distributed according to the discrete
-        probability function P(i/lo,up)=1/(up-lo).
-
-        Parameters
-        ----------
-        size (numpy.ndarray):
-            The size of the samples to generate.
-
-        Returns
-        -------
-        (numpy.ndarray):
-            Random samples with shape ``size``.
-        """
-
-        return np.random.randint(self.lo, self.up, size)
-
-
 # TODO: Convert this to a chaospy style distribution
 def custom_histogram(filename):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 numpy==1.16.2
 pandas==0.25
 scipy==1.3.1
-chaospy==3.0.7
+chaospy==3.0.14
 SALib==1.3.8
 pytest==4.3.1
 pytest-pep8==1.0.6

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -106,7 +106,7 @@ def test_worker(tmpdir):
     # Make a random sampler
     vary = {
         "angle": cp.Uniform(0.0, 1.0),
-        "height": uq.distributions.uniform_integer(0, 100),
+        "height": cp.DiscreteUniform(0, 100),
         "velocity": cp.Normal(10.0, 1.0),
         "mass": cp.Uniform(5.0, 1.0)
     }


### PR DESCRIPTION
Related to the issue #69.

- Requirement: chaospy version **3.0.14**.
- The `uniform_integer` is deleted.

In easyvvuq distribution module, it reamins: 

- `legendre` distribution (is @wedeling still using it?)
- Custom distribution from histogram.