### PR TITLE
Make setup.py read its install requirements from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-
 numpy==1.16.2
 pandas==0.25
 scipy==1.3.1
@@ -10,5 +9,5 @@ SQLAlchemy==1.3.8
 sqlalchemy-utils==0.34.2
 jsonpickle==1.2
 cerberus==1.3.1
-dask[complete]==2.4.0
+dask[complete]==2.7.0
 dask_jobqueue==0.6.3

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,7 @@ setup(
 
     author='CCS',
 
-    install_requires=['numpy', 'pandas>=0.24', 'scipy',
-                      'pytest', 'SQLAlchemy', 'chaospy',
-                      'sqlalchemy-utils', 'jsonpickle',
-                      'cerberus', 'SALib'],
+    install_requires=open("requirements.txt", "r").readlines(),
 
     packages=find_packages(),
 


### PR DESCRIPTION
It's weird to have these two different lists of install requirements, so I've edited setup.py to make it read its requirements from the ```requirements.txt``` file directly.

(Addressing Issue #177)