### PR TITLE
Issue117 extend runs

### DIFF
--- a/easyvvuq/analysis/sc_analysis.py
+++ b/easyvvuq/analysis/sc_analysis.py
@@ -297,8 +297,8 @@ class SCAnalysis(BaseAnalysisElement):
         # each diff contains the level indices of to a single
         # Q^1_{k1} X ... X Q^1_{kN} product
         for diff in diff_idx:
-            #if any Q^1_{ki} is below the minimim level, Q^1_{ki} is defined
-            #as zero: do not compute this Q^1_{k1} X ... X Q^1_{kN} product
+            # if any Q^1_{ki} is below the minimim level, Q^1_{ki} is defined
+            # as zero: do not compute this Q^1_{k1} X ... X Q^1_{kN} product
             if not (np.abs(diff) < self.l_norm_min).any():
 
                 # compute the tensor product of parameter and weight values
@@ -717,8 +717,8 @@ class SCAnalysis(BaseAnalysisElement):
                 # perform analysis on each Q^1_l1 X ... X Q^1_l_N tensor prod
                 for diff in diff_idx:
 
-                    #if any Q^1_li is below the minimim level, Q^1_li is defined
-                    #as zero: do not compute this Q^1_l1 X ... X Q^1_l_N tensor prod
+                    # if any Q^1_li is below the minimim level, Q^1_li is defined
+                    # as zero: do not compute this Q^1_l1 X ... X Q^1_l_N tensor prod
                     if not (np.abs(diff) < self.l_norm_min).any():
 
                         # mariginal integral h, integrate over dimensions u'

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -792,7 +792,7 @@ class Campaign:
         ----------
         list_of_run_IDs: list
             The list of run IDs for the runs that should be set to status IGNORED
-        
+
 
         Returns
         -------
@@ -811,7 +811,7 @@ class Campaign:
         ----------
         list_of_run_IDs: list
             The list of run IDs for the runs that should be set to status ENCODED
-        
+
 
         Returns
         -------
@@ -823,7 +823,7 @@ class Campaign:
             if status == Status.NEW:
                 msg = (f"Cannot rerun {run_ID} as it has status NEW, and must"
                        f"be encoded before execution.")
-                raise RuntimeError(msg)       
+                raise RuntimeError(msg)
 
         self.campaign_db.set_run_statuses(list_of_run_IDs, Status.ENCODED)
 

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -770,5 +770,8 @@ class Campaign:
 
         return self._active_sampler
 
+    def ignore_runs(self, list_of_run_IDs):
+        self.campaign_db.set_run_statuses(list_of_run_IDs, Status.IGNORED)
+
     def get_active_app(self):
         return self._active_app

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -787,6 +787,14 @@ class Campaign:
         self.campaign_db.set_run_statuses(list_of_run_IDs, Status.IGNORED)
 
     def rerun(self, list_of_run_IDs):
+
+        for run_ID in list_of_run_IDs:
+            status = self.campaign_db.get_run_status(run_ID)
+            if status == Status.NEW:
+                msg = (f"Cannot rerun {run_ID} as it has status NEW, and must"
+                       f"be encoded before execution.")
+                raise RuntimeError(msg)       
+
         self.campaign_db.set_run_statuses(list_of_run_IDs, Status.ENCODED)
 
     def get_active_app(self):

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -786,5 +786,8 @@ class Campaign:
     def ignore_runs(self, list_of_run_IDs):
         self.campaign_db.set_run_statuses(list_of_run_IDs, Status.IGNORED)
 
+    def rerun(self, list_of_run_IDs):
+        self.campaign_db.set_run_statuses(list_of_run_IDs, Status.ENCODED)
+
     def get_active_app(self):
         return self._active_app

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -671,7 +671,8 @@ class Campaign:
         self.campaign_db.clear_collation(self._active_app['id'])
 
     def recollate(self):
-        """Clears the current collation table, changes all COLLATED status runs back to ENCODED, then runs collate() again
+        """Clears the current collation table, changes all COLLATED status runs
+           back to ENCODED, then runs collate() again
 
         Returns
         -------
@@ -829,6 +830,7 @@ class Campaign:
 
     def get_active_app(self):
         """
-        Returns a dict of information regarding the application that is currently set for this campaign.
+        Returns a dict of information regarding the application that is currently
+        set for this campaign.
         """
         return self._active_app

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -784,9 +784,39 @@ class Campaign:
         return self._active_sampler
 
     def ignore_runs(self, list_of_run_IDs):
+        """ Flags the specified runs to be IGNORED in future collation. Note that
+        this does NOT remove previously collated results from the collation table.
+        For that you must refresh the collation by running recollate().
+
+        Parameters
+        ----------
+        list_of_run_IDs: list
+            The list of run IDs for the runs that should be set to status IGNORED
+        
+
+        Returns
+        -------
+
+        """
         self.campaign_db.set_run_statuses(list_of_run_IDs, Status.IGNORED)
 
     def rerun(self, list_of_run_IDs):
+        """ Sets the status of the specified runs to ENCODED, so that their results
+        may be recollated later (presumably after extending, rerunning or otherwise
+        modifying the data in the relevant run folder). Note that this method will
+        NOT perform any execution - it simply flags the run in EasyVVUQ as being
+        uncollated. Actual execution is (as usual) the job of the user or middleware.
+
+        Parameters
+        ----------
+        list_of_run_IDs: list
+            The list of run IDs for the runs that should be set to status ENCODED
+        
+
+        Returns
+        -------
+
+        """
 
         for run_ID in list_of_run_IDs:
             status = self.campaign_db.get_run_status(run_ID)
@@ -798,4 +828,7 @@ class Campaign:
         self.campaign_db.set_run_statuses(list_of_run_IDs, Status.ENCODED)
 
     def get_active_app(self):
+        """
+        Returns a dict of information regarding the application that is currently set for this campaign.
+        """
         return self._active_app

--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -667,6 +667,22 @@ class Campaign:
         info = {'num_collated': num_collated}
         self.log_element_application(self._active_app_collater, info)
 
+    def clear_collation(self):
+        self.campaign_db.clear_collation(self._active_app['id'])
+
+    def recollate(self):
+        """Clears the current collation table, changes all COLLATED status runs back to ENCODED, then runs collate() again
+
+        Returns
+        -------
+
+        """
+
+        self.clear_collation()
+        collated_run_ids = list(self.campaign_db.run_ids(status=Status.COLLATED))
+        self.campaign_db.set_run_statuses(collated_run_ids, Status.ENCODED)
+        self.collate()
+
     def get_collation_result(self):
         """
         Return dataframe containing all collated results
@@ -680,9 +696,6 @@ class Campaign:
 
         """
         return self._active_app_collater.get_collated_dataframe(self, self._active_app['id'])
-
-    def clear_collation(self):
-        self.campaign_db.clear_collation(self._active_app['id'])
 
     def apply_analysis(self, analysis):
         """Run the `analysis` element on the output of the last run collation.

--- a/easyvvuq/constants.py
+++ b/easyvvuq/constants.py
@@ -55,3 +55,4 @@ class Status(IntEnum):
     NEW = 1
     ENCODED = 2
     COLLATED = 3
+    IGNORED = 4

--- a/easyvvuq/db/sql.py
+++ b/easyvvuq/db/sql.py
@@ -764,7 +764,6 @@ class CampaignDB(BaseCampaignDB):
         for r in selected:
             yield r.run_name
 
-
     def get_num_runs(self, campaign=None, sampler=None, status=None, not_status=None):
         """
         Returns the number of runs matching the filtering criteria.

--- a/easyvvuq/db/sql.py
+++ b/easyvvuq/db/sql.py
@@ -732,6 +732,39 @@ class CampaignDB(BaseCampaignDB):
         for r in selected:
             yield r.run_name, self._run_to_dict(r)
 
+    def run_ids(self, campaign=None, sampler=None, status=None, not_status=None, app_id=None):
+        """
+        A generator to return all run IDs for selected `campaign` and `sampler`.
+
+        Parameters
+        ----------
+        campaign: int or None
+            Campaign id to filter for.
+        sampler: int or None
+            Sampler id to filter for.
+        status: enum(Status) or None
+            Status string to filter for.
+        not_status: enum(Status) or None
+            Exclude runs with this status string
+
+        Returns
+        -------
+        str:
+            run ID for each selected run, one at a time.
+
+        """
+
+        selected = self._select_runs(
+            campaign=campaign,
+            sampler=sampler,
+            status=status,
+            not_status=not_status,
+            app_id=app_id)
+
+        for r in selected:
+            yield r.run_name
+
+
     def get_num_runs(self, campaign=None, sampler=None, status=None, not_status=None):
         """
         Returns the number of runs matching the filtering criteria.

--- a/easyvvuq/decoders/json.py
+++ b/easyvvuq/decoders/json.py
@@ -105,7 +105,7 @@ class JSONDecoder(BaseDecoder, decoder_name="json"):
         for col in self.output_columns:
             if isinstance(col, str):
                 data.append((col, to_np_if_list(raw_data[col])))
-            elif type(col) is list:
+            elif isinstance(col, list):
                 data.append(('.'.join(col), to_np_if_list(get_value(raw_data, col))))
         data = pd.DataFrame(dict(data))
 

--- a/easyvvuq/sampling/stochastic_collocation.py
+++ b/easyvvuq/sampling/stochastic_collocation.py
@@ -74,7 +74,7 @@ class SCSampler(BaseSamplingElement, sampler_name="sc_sampler"):
         self.joint_dist = cp.J(*params_distribution)
 
         # The quadrature information: order, rule and sparsity
-        if type(polynomial_order) == int:
+        if isinstance(polynomial_order, int):
             print('Received integer polynomial order, assuming isotropic grid')
             self.polynomial_order = [polynomial_order for i in range(N)]
         else:
@@ -120,7 +120,7 @@ class SCSampler(BaseSamplingElement, sampler_name="sc_sampler"):
 
         if not sparse:
             # Generate collocation grid via chaospy
-            #NOTE: different poly orders per dimension does not work for all
+            # NOTE: different poly orders per dimension does not work for all
             #      guadarture rules - use self.generate_grid subroutine instead
             # # the nodes of the collocation grid
             # xi_d, _ = cp.generate_quadrature(self.polynomial_order,
@@ -128,7 +128,7 @@ class SCSampler(BaseSamplingElement, sampler_name="sc_sampler"):
             #                                  rule=quadrature_rule)
             # self.xi_d = xi_d.T
 
-            #generate collocation grid locally
+            # generate collocation grid locally
             l_norm = np.array([self.polynomial_order])
             self.xi_d = self.generate_grid(L, N, l_norm)
 

--- a/tests/test_anisotropic_order.py
+++ b/tests/test_anisotropic_order.py
@@ -57,7 +57,7 @@ def test_anisotropic_order(tmpdir):
         "f": cp.Uniform(0.95, 1.05)
     }
 
-    #different orders for the 2 parameters
+    # different orders for the 2 parameters
     my_sampler = uq.sampling.SCSampler(vary=vary, polynomial_order=[2, 5],
                                        quadrature_rule="G")
 
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     ax = fig.add_subplot(122, xlabel='location x', ylabel='velocity u',
                          title='Surrogate samples')
 
-    #generate n_mc samples from the input distributions
+    # generate n_mc samples from the input distributions
     n_mc = 20
     xi_mc = np.zeros([20, 2])
     idx = 0

--- a/tests/test_jinja_encoder.py
+++ b/tests/test_jinja_encoder.py
@@ -111,14 +111,14 @@ def test_jinjaencoder(tmpdir):
 
     vary = {
         "Nc_0": cp.Uniform(50e6, 100e6),
-        #"cf": cp.Uniform(2.4, 2.6),
-        #"cn": cp.Uniform(0.5, 0.9),
-        #"Rigc": cp.Uniform(0.1, 0.4),
-        #"Prandtl": cp.Uniform(0.2, 0.4),
-        #"z0": cp.Uniform(1e-4, 2e-4),
+        # "cf": cp.Uniform(2.4, 2.6),
+        # "cn": cp.Uniform(0.5, 0.9),
+        # "Rigc": cp.Uniform(0.1, 0.4),
+        # "Prandtl": cp.Uniform(0.2, 0.4),
+        # "z0": cp.Uniform(1e-4, 2e-4),
         "l_sb": cp.DiscreteUniform(0, 1),
-        #"Nh": cp.DiscreteUniform(10, 20),
-        #"extent": cp.Uniform(1000, 2000),
+        # "Nh": cp.DiscreteUniform(10, 20),
+        # "extent": cp.Uniform(1000, 2000),
         "seed": cp.Uniform(1, 2000),
     }
 
@@ -142,6 +142,7 @@ def test_jinjaencoder(tmpdir):
     my_campaign.set_sampler(my_sampler)
     my_campaign.draw_samples()
     my_campaign.populate_runs_dir()
+
 
 if __name__ == "__main__":
     test_jinjaencoder("/tmp/")

--- a/tests/test_recollate.py
+++ b/tests/test_recollate.py
@@ -109,8 +109,6 @@ def test_recollate(tmpdir):
                         collater=collater)
     my_campaign.set_app("cannon")
 
-    print(my_campaign)
-
     my_campaign.set_sampler(sampler)
     my_campaign.draw_samples()
     my_campaign.populate_runs_dir()
@@ -119,16 +117,18 @@ def test_recollate(tmpdir):
     my_campaign.apply_for_each_run_dir(actions)
     my_campaign.collate()
 
-    print("Before:\n", my_campaign.get_collation_result())
-    
+    # Set some runs to be IGNORED, then recollate all
     my_campaign.ignore_runs(ignore_list)
     my_campaign.recollate()
 
-    print("After:\n", my_campaign.get_collation_result())
+    # Check that the right number of rows are in the collation dataframe 
+    assert(len(my_campaign.get_collation_result().index) == num_samples - len(ignore_list))
+
+    # Rerun some runs
+    my_campaign.rerun(['Run_2', 'Run_3', 'Run_4'])
+    my_campaign.apply_for_each_run_dir(actions)
 
     pprint(my_campaign._log)
-
-    assert(len(my_campaign.get_collation_result().index) == num_samples - len(ignore_list))
 
 if __name__ == "__main__":
     test_recollate('/tmp/')

--- a/tests/test_recollate.py
+++ b/tests/test_recollate.py
@@ -93,7 +93,7 @@ def test_recollate(tmpdir):
     decoder = uq.decoders.SimpleCSV(
         target_filename='output.csv', output_columns=output_cols, header=0)
     collater = uq.collate.AggregateSamples(average=False)
-    
+
     # Set up samplers
     vary = {
         "gravity": cp.Uniform(9.8, 1.0),
@@ -121,7 +121,7 @@ def test_recollate(tmpdir):
     my_campaign.ignore_runs(ignore_list)
     my_campaign.recollate()
 
-    # Check that the right number of rows are in the collation dataframe 
+    # Check that the right number of rows are in the collation dataframe
     assert(len(my_campaign.get_collation_result().index) == num_samples - len(ignore_list))
 
     # Rerun some runs
@@ -129,6 +129,7 @@ def test_recollate(tmpdir):
     my_campaign.apply_for_each_run_dir(actions)
 
     pprint(my_campaign._log)
+
 
 if __name__ == "__main__":
     test_recollate('/tmp/')

--- a/tests/test_run_extension.py
+++ b/tests/test_run_extension.py
@@ -1,0 +1,127 @@
+import easyvvuq as uq
+import chaospy as cp
+import os
+import sys
+import pytest
+import logging
+from pprint import pformat, pprint
+
+__copyright__ = """
+
+    Copyright 2018 Robin A. Richardson, David W. Wright
+
+    This file is part of EasyVVUQ
+
+    EasyVVUQ is free software: you can redistribute it and/or modify
+    it under the terms of the Lesser GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    EasyVVUQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    Lesser GNU General Public License for more details.
+
+    You should have received a copy of the Lesser GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+__license__ = "LGPL"
+
+
+# If cannonsim has not been built (to do so, run the Makefile in tests/cannonsim/src/)
+# then skip this test
+if not os.path.exists("tests/cannonsim/bin/cannonsim"):
+    pytest.skip(
+        "Skipping cannonsim test (cannonsim is not installed in tests/cannonsim/bin/)",
+        allow_module_level=True)
+
+cannonsim_path = os.path.realpath(os.path.expanduser("tests/cannonsim/bin/cannonsim"))
+
+logging.basicConfig(level=logging.CRITICAL)
+
+
+def test_run_extension(tmpdir):
+    # Define parameter space for the cannonsim app
+    params = {
+        "angle": {
+            "type": "float",
+            "min": 0.0,
+            "max": 6.28,
+            "default": 0.79},
+        "air_resistance": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1.0,
+            "default": 0.2},
+        "height": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1000.0,
+            "default": 1.0},
+        "time_step": {
+            "type": "float",
+            "min": 0.0001,
+            "max": 1.0,
+            "default": 0.01},
+        "gravity": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1000.0,
+            "default": 9.8},
+        "mass": {
+            "type": "float",
+            "min": 0.0001,
+            "max": 1000.0,
+            "default": 1.0},
+        "velocity": {
+            "type": "float",
+            "min": 0.0,
+            "max": 1000.0,
+            "default": 10.0}}
+
+    # Create an encoder and decoder for the cannonsim app
+    encoder = uq.encoders.GenericEncoder(
+        template_fname='tests/cannonsim/test_input/cannonsim.template',
+        delimiter='#',
+        target_filename='in.cannon')
+    output_cols = ['Dist', 'lastvx', 'lastvy']
+    decoder = uq.decoders.SimpleCSV(
+        target_filename='output.csv', output_columns=output_cols, header=0)
+    collater = uq.collate.AggregateSamples(average=False)
+    
+    # Set up samplers
+    vary = {
+        "gravity": cp.Uniform(9.8, 1.0),
+        "mass": cp.Uniform(2.0, 10.0),
+    }
+    sampler = uq.sampling.RandomSampler(vary=vary, max_num=10)
+
+    my_campaign = uq.Campaign(name='ignore', work_dir=tmpdir)
+    my_campaign.add_app(name="cannon",
+                        params=params,
+                        encoder=encoder,
+                        decoder=decoder,
+                        collater=collater)
+    my_campaign.set_app("cannon")
+
+    my_campaign.set_sampler(sampler)
+    my_campaign.draw_samples()
+    my_campaign.populate_runs_dir()
+
+    actions = uq.actions.ExecuteLocal("tests/cannonsim/bin/cannonsim in.cannon output.csv")
+    my_campaign.apply_for_each_run_dir(actions)
+    my_campaign.collate()
+
+    print("Before:\n", my_campaign.get_collation_result())
+    
+    my_campaign.ignore_runs(['Run_1', 'Run_5', 'Run_10'])
+    #my_campaign.recollate()
+
+    print("After:\n", my_campaign.get_collation_result())
+
+    pprint(my_campaign.list_runs())
+
+
+if __name__ == "__main__":
+    test_run_extension('/tmp/')


### PR DESCRIPTION
Provides some functionality to solve issue #117 on a basic level.

```Campaign``` now has three extra methods:
* ```ignore_runs()``` which allows the user to specify runs which should be omitted from future collation attempts.
* ```rerun()``` which can be used to flag runs such that their results will be picked up in future collation. Also they will be picked up by methods such as ```apply_for_each_run_dir()```, allowing them to be executed again (if that's how the user is handling execution).
* ```recollate()``` which clears and rebuilds the entire collation table anew.

```recollate()``` is the most important as it is (normally) needed to see the effects of rerunning or ignoring runs. Simply calling ```collate()``` again would append any changes to the existing collated results.