### PR TITLE
Replica Sampler

### DIFF
--- a/docs/source/easyvvuq.sampling.rst
+++ b/docs/source/easyvvuq.sampling.rst
@@ -52,6 +52,13 @@ easyvvuq.sampling.stochastic\_collocation module
     :undoc-members:
     :show-inheritance:
 
+       easyvvuq.sampling.replica\_sampler
+------------------------------------------------
+
+.. automodule:: easyvvuq.sampling.replica_sampler
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 Module contents
 ---------------

--- a/easyvvuq/sampling/__init__.py
+++ b/easyvvuq/sampling/__init__.py
@@ -16,6 +16,7 @@ from .sweep import BasicSweep
 from .sampler_of_samplers import MultiSampler
 from .quasirandom import LHCSampler
 from .empty import EmptySampler
+from .replica_sampler import ReplicaSampler
 
 __copyright__ = """
 

--- a/easyvvuq/sampling/replica_sampler.py
+++ b/easyvvuq/sampling/replica_sampler.py
@@ -1,0 +1,19 @@
+class ReplicaSampler(BaseSamplingElement, name='replica_sampler'):
+    def __init__(self, sampler, ensemble_col):
+        self.sampler = sampler
+        self.ensemble_col = ensemble_col
+
+    def is_finite(self):
+        return False
+
+    def element_version(self):
+        return '0.1'
+
+    def n_samples(self):
+        raise RuntimeError("You can't get the number of samples in an infinite sampler")
+
+    def __next__(self):
+        pass
+
+    def is_restartable(self):
+        return False

--- a/easyvvuq/sampling/replica_sampler.py
+++ b/easyvvuq/sampling/replica_sampler.py
@@ -3,6 +3,8 @@ from easyvvuq.sampling import BaseSamplingElement
 
 class ReplicaSampler(BaseSamplingElement, sampler_name='replica_sampler'):
     def __init__(self, sampler, ensemble_col='ensemble'):
+        if not sampler.is_finite():
+            raise RuntimeError("Replica sampler only works with finite samplers")
         self.sampler = sampler
         self.ensemble_col = ensemble_col
         self.history = []

--- a/easyvvuq/sampling/replica_sampler.py
+++ b/easyvvuq/sampling/replica_sampler.py
@@ -5,6 +5,7 @@ class ReplicaSampler(BaseSamplingElement, sampler_name='replica_sampler'):
     def __init__(self, sampler, ensemble_col='ensemble'):
         self.sampler = sampler
         self.ensemble_col = ensemble_col
+        self.history = []
 
     def is_finite(self):
         return False

--- a/easyvvuq/sampling/replica_sampler.py
+++ b/easyvvuq/sampling/replica_sampler.py
@@ -1,3 +1,16 @@
+"""Replica Sampler
+
+Summary
+-------
+
+Primarily intended for sampling the same paramater values but with
+different random seed. Other uses may be possible. It takes a finite
+sampler and produces an infinite sampler from it. This infinite
+sampler loops through the parameters produced by the finite sampler
+and at each cycle adds a unique id number for that cycle to the
+parameter dictionary.
+"""
+
 from easyvvuq.sampling import BaseSamplingElement
 from itertools import cycle
 

--- a/easyvvuq/sampling/replica_sampler.py
+++ b/easyvvuq/sampling/replica_sampler.py
@@ -1,4 +1,5 @@
 from easyvvuq.sampling import BaseSamplingElement
+from itertools import cycle
 
 
 class ReplicaSampler(BaseSamplingElement, sampler_name='replica_sampler'):
@@ -8,6 +9,12 @@ class ReplicaSampler(BaseSamplingElement, sampler_name='replica_sampler'):
         self.sampler = sampler
         self.ensemble_col = ensemble_col
         self.history = []
+        for sample in sampler:
+            self.history.append(sample)
+        self.size = len(self.history)
+        self.cycle = cycle(self.history)
+        self.ensemble = 0
+        self.counter = 0
 
     def is_finite(self):
         return False
@@ -19,7 +26,14 @@ class ReplicaSampler(BaseSamplingElement, sampler_name='replica_sampler'):
         raise RuntimeError("You can't get the number of samples in an infinite sampler")
 
     def __next__(self):
-        pass
+        params = dict(next(self.cycle))
+        if self.counter < self.size - 1:
+            self.counter += 1
+        else:
+            self.counter = 0
+            self.ensemble += 1
+        params[self.ensemble_col] = self.ensemble
+        return params
 
     def is_restartable(self):
         return False

--- a/easyvvuq/sampling/replica_sampler.py
+++ b/easyvvuq/sampling/replica_sampler.py
@@ -16,6 +16,16 @@ from itertools import cycle
 
 
 class ReplicaSampler(BaseSamplingElement, sampler_name='replica_sampler'):
+    """Replica Sampler
+
+    Parameters
+    ----------
+    sampler : an instance of a class derived from  BaseSamplingElement
+        a finite sampler to loop over
+
+    ensemble_col : string
+        a parameter name for the ensemble id
+    """
     def __init__(self, sampler, ensemble_col='ensemble'):
         if not sampler.is_finite():
             raise RuntimeError("Replica sampler only works with finite samplers")

--- a/easyvvuq/sampling/replica_sampler.py
+++ b/easyvvuq/sampling/replica_sampler.py
@@ -1,5 +1,8 @@
-class ReplicaSampler(BaseSamplingElement, name='replica_sampler'):
-    def __init__(self, sampler, ensemble_col):
+from easyvvuq.sampling import BaseSamplingElement
+
+
+class ReplicaSampler(BaseSamplingElement, sampler_name='replica_sampler'):
+    def __init__(self, sampler, ensemble_col='ensemble'):
         self.sampler = sampler
         self.ensemble_col = ensemble_col
 

--- a/tests/test_sampling_replica_sampler.py
+++ b/tests/test_sampling_replica_sampler.py
@@ -6,7 +6,7 @@ import pytest
 
 @pytest.fixture
 def replica_sampler():
-    return ReplicaSampler(BasicSweep({'a' : [1, 2], 'b' : [3, 4]}))
+    return ReplicaSampler(BasicSweep({'a': [1, 2], 'b': [3, 4]}))
 
 
 def test_infite_exception():

--- a/tests/test_sampling_replica_sampler.py
+++ b/tests/test_sampling_replica_sampler.py
@@ -1,0 +1,35 @@
+from easyvvuq.sampling import ReplicaSampler
+from easyvvuq.sampling import BasicSweep
+from easyvvuq.sampling import EmptySampler
+import pytest
+
+
+@pytest.fixture
+def replica_sampler():
+    return ReplicaSampler(BasicSweep({'a' : [1, 2], 'b' : [3, 4]}))
+
+
+def test_infite_exception():
+    with pytest.raises(RuntimeError):
+        ReplicaSampler(EmptySampler())
+
+
+def test_is_finite(replica_sampler):
+    assert(not replica_sampler.is_finite())
+
+
+def test_element_version(replica_sampler):
+    assert(replica_sampler.element_version() == '0.1')
+
+
+def test_n_samples(replica_sampler):
+    with pytest.raises(RuntimeError):
+        replica_sampler.n_samples()
+
+
+def test_replica_sampler(replica_sampler):
+    for _ in range(18):
+        params = next(replica_sampler)
+    assert(params['a'] == 1)
+    assert(params['b'] == 4)
+    assert(params['ensemble'] == 4)


### PR DESCRIPTION
I want a sampler that will behave the following way:

```
sampler = BasicSweep({'a': [1, 2, 3], 'b' : [4, 5]})
replica_sampler = ReplicaSampler(sampler, 'ensemble')
for _ in range(1000):
    params = replica_sampler.next()
    print(params)
```

Would create a new sampler that would iterate across the values of basic sweep many times adding a new column for the ensemble index. Would work for any finite sampler. In the example above it would output param dictionaries as so:

```
{'a': 1, 'b': 4, 'ensemble' : 0}
...
{'a': 3, 'b': 5, 'ensemble' : 0}
{'a': 1, 'b': 4, 'ensemble' : 1}
...
{'a': 3, 'b': 5, 'ensemble' : 1}
{'a': 1, 'b': 4, 'ensemble' : 2}
...
```

and so on. This would allow taking a finite sampler and producing replicas for it using different seeds for example. And if you wanted more accuracy you could just generate more samples.