### PR TITLE
Add wheel to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 pandas
 scipy
+wheel
 chaospy
 SALib
 pytest


### PR DESCRIPTION
I had the following error when I installed easyVVUQ in a new machine:
```
  Building wheel for easyvvuq (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /home/jalal/workspace/venv/vecma/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-3yn_f6sx/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-3yn_f6sx/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-ug973lv3
       cwd: /tmp/pip-req-build-3yn_f6sx/
  Complete output (8 lines):
  /home/jalal/workspace/venv/vecma/lib/python3.8/site-packages/setuptools/dist.py:473: UserWarning: Normalizing 'v0.7.1.5+3.gc67ab89' to '0.7.1.5+3.gc67ab89'
    warnings.warn(
  usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: setup.py --help [cmd1 cmd2 ...]
     or: setup.py --help-commands
     or: setup.py cmd --help
  
  error: invalid command 'bdist_wheel'
  ----------------------------------------
  ERROR: Failed building wheel for easyvvuq
```
Fix: pip intstall wheel 