### PR TITLE
Add optional axes argument to plotting routines

### DIFF
--- a/easyvvuq/analysis/results.py
+++ b/easyvvuq/analysis/results.py
@@ -339,7 +339,7 @@ class AnalysisResults:
 
     def plot_sobols_first(self, qoi, inputs=None, withdots=False,
                           ylabel=None, xlabel=None, filename=None,
-                          dpi=None):
+                          dpi=None, ax=None):
         """Plot first order sobol indices.
 
         Parameters
@@ -358,6 +358,13 @@ class AnalysisResults:
             if None will try to open a plotting window on-screen, otherwise will write the plot to this file, with the type determined by the extension specified
         dpi: int
             dots per inch, quality of the image if a raster format was chosen
+        ax: matplotlib axes object, default None
+            if None, plots to a new axes, otherwise plot to existing axes ax
+
+        Returns
+        -------
+        matplotlib axes object
+            the actual axes plotted to
         """
         if qoi not in self.qois:
             raise RuntimeError("no such qoi - {}".format(qoi))
@@ -381,24 +388,29 @@ class AnalysisResults:
                 points = [indices]
             else:
                 points.append(self.sobols_first(qoi, input_))
+        if ax is None:
+            fig, ax = plt.subplots()
+        else:
+            fig = ax.get_figure()
         for p, label in zip(points, inputs):
-            plt.plot(p, next(styles), label=label)
-        plt.grid(True)
+            ax.plot(p, next(styles), label=label)
+        ax.grid(True)
         if ylabel is None:
-            plt.ylabel('First Order Sobol Index')
+            ax.set_ylabel('First Order Sobol Index')
         else:
-            plt.ylabel(ylabel)
+            ax.set_ylabel(ylabel)
         if xlabel is None:
-            plt.xlabel(qoi)
+            ax.set_xlabel(qoi)
         else:
-            plt.xlabel(xlabel)
-        plt.legend()
+            ax.set_xlabel(xlabel)
+        ax.legend()
         if filename is None:
-            plt.show()
+            fig.show()
         else:
-            plt.savefig(filename, dpi=dpi)
+            fig.savefig(filename, dpi=dpi)
+        return ax
 
-    def plot_moments(self, qoi, ylabel=None, xlabel=None, alpha=0.5, filename=None, dpi=None):
+    def plot_moments(self, qoi, ylabel=None, xlabel=None, alpha=0.5, filename=None, dpi=None, ax=None):
         """Plot statistical moments for this analysis.
 
         Parameters
@@ -416,33 +428,45 @@ class AnalysisResults:
             write the plot to this file, with the type determined by the extension specified
         dpi: int
             dots per inch, quality of the image if a raster format was chosen
+        ax: matplotlib axes object, default None
+            if None, plots to a new axes, otherwise plot to existing axes ax
+
+        Returns
+        -------
+        matplotlib axes object
+            the actual axes plotted to
         """
         if qoi not in self.qois:
             raise RuntimeError("no such qoi - {}".format(qoi))
         import matplotlib.pyplot as plt
+        if ax is None:
+            fig, ax = plt.subplots()
+        else:
+            fig = ax.get_figure()
         xs = np.arange(len(self.describe(qoi, 'mean')))
-        plt.fill_between(
+        ax.fill_between(
             xs, self.describe(
                 qoi, 'min'), self.describe(
                 qoi, 'max'), label='min-max', alpha=alpha)
-        plt.fill_between(xs, self.describe(qoi, 'mean') -
-                         self.describe(qoi, 'std'), self.describe(qoi, 'mean') +
-                         self.describe(qoi, 'std'), label='std', alpha=alpha)
-        plt.plot(self.describe(qoi, 'mean'), label='mean')
-        plt.grid(True)
+        ax.fill_between(xs, self.describe(qoi, 'mean') -
+                        self.describe(qoi, 'std'), self.describe(qoi, 'mean') +
+                        self.describe(qoi, 'std'), label='std', alpha=alpha)
+        ax.plot(self.describe(qoi, 'mean'), label='mean')
+        ax.grid(True)
         if ylabel is None:
-            plt.ylabel("Value")
+            ax.set_ylabel("Value")
         else:
-            plt.ylabel(ylabel)
+            ax.set_ylabel(ylabel)
         if xlabel is None:
-            plt.xlabel(qoi)
+            ax.set_xlabel(qoi)
         else:
-            plt.xlabel(xlabel)
-        plt.legend()
+            ax.set_xlabel(xlabel)
+        ax.legend()
         if filename is None:
-            plt.show()
+            fig.show()
         else:
-            plt.savefig(filename, dpi=dpi)
+            fig.savefig(filename, dpi=dpi)
+        return ax
 
     @staticmethod
     def _keys_to_tuples(dictionary):


### PR DESCRIPTION
By default, now plots to a new figure and axes, rather than
overplotting on whatever happens to be the current axes. The optional
argument `ax` allows plotting to an existing axes.

This shouldn't break existing workflows, but something like the following:

```python
plt.figure()
results.plot_moments("QoI")
```
would result in an extra blank figure being created. There are two solutions to that:

```diff
- plt.figure()
  results.plot_moments("QoI")
```
or
```diff
- plt.figure()
- results.plot_moments("QoI")
+ _, ax = plt.subplots() 
+ results.plot_moments("QoI", ax=ax)
```

If this PR is interesting, I'm happy to go through and fix any existing tutorials/examples.