### PR TITLE
Fix MCSampler for 1D problems

### DIFF
--- a/easyvvuq/sampling/mc_sampler.py
+++ b/easyvvuq/sampling/mc_sampler.py
@@ -108,8 +108,12 @@ class MCSampler(RandomSampler, sampler_name='mc_sampler'):
         # number of different sampling matrices
         step = self.n_params + 2
         # store M2 first, with entries separated by step places
+        if M_2.ndim == 1:
+            M_2 = M_2.reshape([-1, 1])
         self.xi_mc[0:self.max_num:step] = M_2
         # store M1 entries last
+        if M_1.ndim == 1:
+            M_1 = M_1.reshape([-1, 1])
         self.xi_mc[(step - 1):self.max_num:step] = M_1
         # store N_i entries between M2 and M1
         for i in range(self.n_params):

--- a/tests/test_sampling_mc.py
+++ b/tests/test_sampling_mc.py
@@ -1,0 +1,24 @@
+import pytest
+import chaospy as cp
+from easyvvuq.sampling import MCSampler
+from easyvvuq.sampling.base import Vary
+
+
+def test_sampling():
+    vary = {'a': cp.Uniform(-5, 0), 'b': cp.Uniform(2, 10)}
+    sampler = MCSampler(vary, 100)
+    assert(sampler.n_samples() == 400)
+    for _ in range(sampler.n_samples()):
+        sample = next(sampler)
+        assert(sample['a'] >= -5 and sample['a'] <= 0)
+        assert(sample['b'] >= 2 and sample['b'] <= 10)
+    with pytest.raises(StopIteration):
+        next(sampler)
+
+
+def test_sampling_1D():
+    vary = {'a': cp.Uniform(-1, 1)}
+    sampler = MCSampler(vary, 100)
+    # This used to fail in the saltelli subroutine if there was only 1 input
+    for _ in range(sampler.n_samples()):
+        sample = next(sampler)


### PR DESCRIPTION
The MC sampler failed in the `saltelli` subroutine, when using only 1 input in `vary`. This is fixed now. I also added a test which checks this (`test/test_sampling_mc.py`)