### PR TITLE
Fix for issue #359 -- use fully expanded work_dir path in creating te…

### DIFF
--- a/easyvvuq/campaign.py
+++ b/easyvvuq/campaign.py
@@ -155,7 +155,7 @@ class Campaign:
         self._campaign_dir = None
 
         if db_location is None:
-            self._campaign_dir = tempfile.mkdtemp(prefix=name, dir=work_dir)
+            self._campaign_dir = tempfile.mkdtemp(prefix=name, dir=self.work_dir)
             self.db_location = "sqlite:///" + self._campaign_dir + "/campaign.db"
         else:
             self.db_location = db_location


### PR DESCRIPTION
…mporary campaign directory

Prior to this change not specifying work_dir would lead to campaign runs appearing under `/tmp` but the database appearing under the current directory. With this change both appear under the current directory.