### PR TITLE
Feature/decrease needed memory (Issue 404)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,35 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt

--- a/easyvvuq/analysis/pce_analysis.py
+++ b/easyvvuq/analysis/pce_analysis.py
@@ -182,7 +182,7 @@ class PCEAnalysisResults(QMCAnalysisResults):
 
 class PCEAnalysis(BaseAnalysisElement):
 
-    def __init__(self, sampler=None, qoi_cols=None, sampling=False, noCorrelationMatrices=False, noOutputDistributions=False):
+    def __init__(self, sampler=None, qoi_cols=None, sampling=False, CorrelationMatrices=True, OutputDistributions=True):
         """Analysis element for polynomial chaos expansion (PCE).
 
         Parameters
@@ -193,7 +193,13 @@ class PCEAnalysis(BaseAnalysisElement):
             Column names for quantities of interest (for which analysis is
             performed).
         sampling : True if chaospy sampling method to be used for calculating
-            statitical quantities; otherwise [default] the pce coefficients are used
+            statistical quantities; otherwise [default] the pce coefficients are used
+        CorrelationMatrices : boolean
+            if False then disable the calculation of the Correlation Matrices, otherwise 
+            [default] calculate them
+        OutputDistributions : boolean
+            if False then disable the calculation of the Output Distributions, otherwise
+            [default] calculate them
         """
 
         if sampler is None:
@@ -211,8 +217,8 @@ class PCEAnalysis(BaseAnalysisElement):
         self.sampling = sampling
         self.output_type = OutputType.SUMMARY
         self.sampler = sampler
-        self.noCorrelationMatrices = noCorrelationMatrices
-        self.noOutputDistributions = noOutputDistributions
+        self.CorrelationMatrices = CorrelationMatrices
+        self.OutputDistributions = OutputDistributions
 
     def element_name(self):
         """Name for this element for logging purposes.
@@ -512,7 +518,7 @@ class PCEAnalysis(BaseAnalysisElement):
                     warnings.warn(f"Skipping computation of cp.Corr", RuntimeWarning)
                     results['correlation_matrices'][k] = None
                 else:
-                    if not self.noCorrelationMatrices:
+                    if self.CorrelationMatrices:
                         results['correlation_matrices'][k] = cp.Corr(fit, self.sampler.distribution)
                     else:
                         warnings.warn(f"Skipping computation of cp.Corr", RuntimeWarning)
@@ -528,7 +534,7 @@ class PCEAnalysis(BaseAnalysisElement):
                     warnings.warn(f"Skipping computation of cp.QoI_Dist", RuntimeWarning)
                     results['output_distributions'][k] = None
                 else:
-                    if not self.noOutputDistributions:
+                    if self.OutputDistributions:
                         results['output_distributions'][k] = cp.QoI_Dist( fit, self.sampler.distribution)
                     else:
                         warnings.warn(f"Skipping computation of cp.QoI_Dist", RuntimeWarning)


### PR DESCRIPTION
As described in https://github.com/UCL-CCS/EasyVVUQ/issues/404, the PCE analysis code would sometimes use large amounts of memory.  This pull request makes it possible to disable the calculation of the Correlation Matrices and Output Distributions.  For one example, this decreased the memory usage to 2% of that previously required, and decreased the elapsed time to 12.7% of that previously required.
