### PR TITLE
Update Dockerfile

### DIFF
--- a/tutorials/kubernetes/Dockerfile
+++ b/tutorials/kubernetes/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get install -y python3-pip && \
     apt-get install -y git && \
     apt-get install -y tini && \
-    pip3 install easyvvuq && \
+    pip3 install easyvvuq --break-system-packages && \
     git clone https://github.com/UCL-CCS/EasyVVUQ.git
 
 ENTRYPOINT ["tini", "--"]


### PR DESCRIPTION
Try to fix the failure when executing the action

build
Command failed: docker build -f Dockerfile -t docker.io/***/easyvvuq:latest .

From the error messages:

RUN apt-get update &&     apt-get install -y python3-pip &&     apt-get install -y git &&     apt-get install -y tini &&     pip3 install easyvvuq &&     git clone https://github.com/UCL-CCS/EasyVVUQ.git:
22.57     sure you have python3-full installed.
22.57     
22.57     If you wish to install a non-Debian packaged Python application,
22.57     it may be easiest to use pipx install xyz, which will manage a
22.57     virtual environment for you. Make sure you have pipx installed.
22.57     
22.57     See /usr/share/doc/python3.12/README.venv for more information.
22.57 
22.57 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.