### PR TITLE
Fix for non-vectorized bootstraping in QMC Analysis

### DIFF
--- a/src/easyvvuq/analysis/qmc_analysis.py
+++ b/src/easyvvuq/analysis/qmc_analysis.py
@@ -414,8 +414,9 @@ class QMCAnalysis(BaseAnalysisElement):
                 #non-vectorized implementation
                 for i in range(n_bootstrap):
                     #resampled sample matrices of size (n_mc, n_qoi)
-                    sobols_first[i] = self._first_order(f_M2[r[i]], f_M1[r[i]], f_Ni[r[i], j])
-                    sobols_total[i] = self._total_order(f_M2[r[i]], f_M1[r[i]], f_Ni[r[i], j])
+                    indices = r[:, i]  
+                    sobols_first[i] = self._first_order(f_M2[indices], f_M1[indices], f_Ni[indices, j])
+                    sobols_total[i] = self._total_order(f_M2[indices], f_M1[indices], f_Ni[indices, j])
 
             # compute confidence intervals based on percentiles
             _, low_first, high_first = confidence_interval(sobols_first, value_first,


### PR DESCRIPTION
This PR likely resolves a bug in accessing samples for calculating Sobols in bootstrapped QMC analysis. This happened only in case of large matrices, so it may not be discovered earlier. Please double check if it make sense. 