### PR TITLE
Fix Docker authentication by migrating to GitHub Container Registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,31 +17,21 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-      
-    - name: Check Docker credentials
-      id: docker-check
-      if: github.event_name != 'pull_request' && github.repository == 'UCL-CCS/EasyVVUQ'
-      run: |
-        if [[ -n "${{ secrets.DOCKER_USERNAME }}" && -n "${{ secrets.DOCKER_PASSWORD }}" ]]; then
-          echo "docker-available=true" >> $GITHUB_OUTPUT
-        else
-          echo "docker-available=false" >> $GITHUB_OUTPUT
-        fi
 
-    - name: Log in to Docker Hub
+    - name: Log in to GitHub Container Registry
       id: docker-login
-      continue-on-error: true  # Allow workflow to continue if Docker Hub credentials are invalid
-      if: steps.docker-check.outputs.docker-available == 'true'
+      if: github.event_name != 'pull_request' && github.repository == 'UCL-CCS/EasyVVUQ'
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
         
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: orbitfold/easyvvuq
+        images: ghcr.io/ucl-ccs/easyvvuq
         tags: |
           type=ref,event=branch
           type=ref,event=pr
@@ -58,7 +48,7 @@ jobs:
       with:
         context: .
         file: ./Dockerfile
-        push: ${{ steps.docker-check.outputs.docker-available == 'true' && steps.docker-login.outcome == 'success' }}
+        push: ${{ github.event_name != 'pull_request' && github.repository == 'UCL-CCS/EasyVVUQ' && steps.docker-login.outcome == 'success' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha


### PR DESCRIPTION
# Fix Docker Authentication by Migrating to GitHub Container Registry

## Problem
Our Docker workflow has been failing with authentication errors:
- Docker Hub authentication failing for `orbitfold/easyvvuq`
- Invalid/expired `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets
- Workflow failures sending notifications to all developers
- Embarrassing CI failures affecting team productivity

## Solution
Migrate from Docker Hub to **GitHub Container Registry (GHCR)** for a more reliable, secure, and maintainable solution.

## Changes Made

### Registry Migration
```diff
- images: orbitfold/easyvvuq
+ images: ghcr.io/ucl-ccs/easyvvuq
```

### Authentication Simplification  
```diff
- username: ${{ secrets.DOCKER_USERNAME }}
- password: ${{ secrets.DOCKER_PASSWORD }}
+ registry: ghcr.io
+ username: ${{ github.actor }}
+ password: ${{ secrets.GITHUB_TOKEN }}
```