### PR TITLE
Potential fix for code scanning alert no. 295: Use of exit() or quit()

### DIFF
--- a/src/easyvvuq/sampling/pce.py
+++ b/src/easyvvuq/sampling/pce.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import chaospy as cp
 import numpy as np
 import random
@@ -239,7 +240,7 @@ class PCESampler(BaseSamplingElement, sampler_name="PCE_sampler"):
                     self._nodes_dep = Transformations.cholesky(self._nodes, self.vary, self.distribution_dep, regression)
                 else:
                     logging.critical("Error: How did this happen? We are transforming the nodes but not with Rosenblatt nor Cholesky")
-                    exit()
+                    sys.exit(1)
 
         # Projection variante (Pseudo-spectral method)
         else:


### PR DESCRIPTION
Potential fix for [https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/295](https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/295)

Use `sys.exit()` instead of `exit()`.

Best fix in this file:
1. Add `import sys` near the existing imports at the top of `src/easyvvuq/sampling/pce.py`.
2. Replace the `exit()` call in the unexpected transformation branch with `sys.exit(1)` (non-zero code indicates abnormal termination and preserves intended behavior of aborting execution).

This keeps functionality the same (terminate on critical impossible state) while ensuring the symbol always exists.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
