### PR TITLE
Potential fix for code scanning alert no. 294: Use of exit() or quit()

### DIFF
--- a/src/easyvvuq/sampling/pce.py
+++ b/src/easyvvuq/sampling/pce.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import chaospy as cp
 import numpy as np
 import random
@@ -171,7 +172,7 @@ class PCESampler(BaseSamplingElement, sampler_name="PCE_sampler"):
             self.distribution_dep = np.array(distribution)
         else:
             logging.error("Unsupported type of the distribution argument. It should be either cp.Distribution or a matrix-like array")
-            exit()
+            sys.exit(1)
 
         # Build independent joint multivariate distribution considering each uncertain paramter
         if not self.distribution_dep is None:


### PR DESCRIPTION
Potential fix for [https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/294](https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/294)

Replace `exit()` with `sys.exit(...)` and add a standard-library `import sys` at the top of `src/easyvvuq/sampling/pce.py`.

Best minimal fix without changing intended behavior:
- In the imports section, add `import sys`.
- At the error branch around line 174, replace `exit()` with `sys.exit(1)` (non-zero status indicates error, matching the existing logging of an unsupported argument type).

This keeps functionality the same (terminate on unsupported type) while removing reliance on `site.Quitter`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
