### PR TITLE
Potential fix for code scanning alert no. 293: Use of exit() or quit()

### DIFF
--- a/src/easyvvuq/sampling/fd.py
+++ b/src/easyvvuq/sampling/fd.py
@@ -1,5 +1,6 @@
 #from hashlib import shake_128
 import logging
+import sys
 import chaospy as cp
 import numpy as np
 import random
@@ -281,7 +282,7 @@ class FDSampler(BaseSamplingElement, sampler_name="FD_sampler"):
                 #self._perturbations_dep = Transformations.cholesky(self._perturbations, vary_, distribution_)
             else:
                 self.logger.critical("Error: How did this happen? We are transforming the nodes but not with Rosenblatt nor Cholesky")
-                exit()
+                sys.exit()
         
         return
 


### PR DESCRIPTION
Potential fix for [https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/293](https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/293)

Use `sys.exit()` instead of `exit()` and ensure `sys` is imported in `src/easyvvuq/sampling/fd.py`.

Best minimal fix (no functionality change):
1. Add `import sys` near the existing imports.
2. Replace `exit()` in the error branch inside `generate_nodes(...)` with `sys.exit()`.

This preserves current behavior (terminating execution on this critical internal state) while removing dependence on `site.Quitter`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
