### PR TITLE
Potential fix for code scanning alert no. 268: Unnecessary pass

### DIFF
--- a/src/easyvvuq/actions/execute_local.py
+++ b/src/easyvvuq/actions/execute_local.py
@@ -245,7 +245,6 @@ class ExecuteLocal():
         """
         stdout.close()
         stderr.close()
-        pass
 
     def succeeded(self):
         """Will return True if the process finished successfully.


### PR DESCRIPTION
Potential fix for [https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/268](https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/268)

Remove the unnecessary `pass` statement from `ExecuteLocal.finalise` in `src/easyvvuq/actions/execute_local.py`.

- **General fix approach:** In Python, keep `pass` only in empty blocks.
- **Best targeted fix here:** Delete line 248 (`pass`) in the `finalise` method while leaving all existing logic unchanged.
- **File/region:** `src/easyvvuq/actions/execute_local.py`, inside `class ExecuteLocal`, method `finalise`.
- **No imports, new methods, or dependency changes** are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
