### PR TITLE
Potential fix for code scanning alert no. 289: Unused import

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,6 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../../src'))
 
-import sphinx_rtd_theme 
 ###html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 from sphinx.ext.apidoc import main as apidoc_main


### PR DESCRIPTION
Potential fix for [https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/289](https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/289)

Remove the unused import statement from `docs/source/conf.py`.

- General fix: delete imports that are not referenced anywhere in active code.
- Best fix here: remove line 17 (`import sphinx_rtd_theme`) and keep the existing `html_theme = 'sphinx_rtd_theme'` setting unchanged.
- File/region: `docs/source/conf.py`, import section near lines 13–20.
- No new methods/imports/definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
