### PR TITLE
Potential fix for code scanning alert no. 288: Unused import

### DIFF
--- a/tests/test_discrete_distributions.py
+++ b/tests/test_discrete_distributions.py
@@ -9,7 +9,6 @@ This test specifically addresses GitHub issue #169 by testing:
 """
 
 import pytest
-import numpy as np
 import chaospy as cp
 import easyvvuq as uq
 from easyvvuq.actions import CreateRunDirectory, Encode, Decode, ExecuteLocal, Actions


### PR DESCRIPTION
Potential fix for [https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/288](https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/288)

To fix an unused import, remove the import statement for the module that is never referenced. This keeps the test file cleaner and avoids unnecessary dependencies in that module scope.

In `tests/test_discrete_distributions.py`, delete line 12:

- `import numpy as np`

No other code changes are required, since functionality does not rely on `np` in the provided snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
