### PR TITLE
Potential fix for code scanning alert no. 287: Unused import

### DIFF
--- a/src/easyvvuq/utils/discrete_validation.py
+++ b/src/easyvvuq/utils/discrete_validation.py
@@ -4,7 +4,6 @@ Utilities for handling discrete distribution validation in EasyVVUQ.
 This module provides enhanced validation capabilities for discrete distributions
 when used with Stochastic Collocation (SC) and Polynomial Chaos Expansion (PCE) methods.
 """
-import numpy as np
 import chaospy as cp
 from typing import Any, Dict, Union
 


### PR DESCRIPTION
Potential fix for [https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/287](https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/287)

Remove the unused `numpy` import from `src/easyvvuq/utils/discrete_validation.py`.

Best fix (no behavior change):
- In the import section at the top of the file, delete:
  - `import numpy as np`
- Keep all other imports unchanged:
  - `import chaospy as cp`
  - `from typing import Any, Dict, Union`

This eliminates the unnecessary dependency reference and resolves the CodeQL `Unused import` finding without changing runtime functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
