### PR TITLE
Potential fix for code scanning alert no. 286: Unused import

### DIFF
--- a/tests/test_dataset_importer.py
+++ b/tests/test_dataset_importer.py
@@ -2,7 +2,6 @@
 Tests for the dataset importer functionality.
 """
 
-import os
 import json
 import tempfile
 import shutil


### PR DESCRIPTION
Potential fix for [https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/286](https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/286)

Remove the unused `import os` line from `tests/test_dataset_importer.py`.

Best fix without changing behavior:
- In the import block at the top of `tests/test_dataset_importer.py`, delete only `import os`.
- Keep all other imports unchanged.
- No logic, tests, or function signatures need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
