### PR TITLE
Potential fix for code scanning alert no. 285: Unused import

### DIFF
--- a/src/easyvvuq/utils/dataset_importer.py
+++ b/src/easyvvuq/utils/dataset_importer.py
@@ -16,7 +16,6 @@ from typing import List, Dict, Tuple, Optional, Union, Any
 from collections import defaultdict
 
 import easyvvuq as uq
-from easyvvuq.constants import Status
 from easyvvuq.actions import Actions, CreateRunDirectory, Encode, Decode, ExecuteLocal
 
 __copyright__ = """


### PR DESCRIPTION
Potential fix for [https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/285](https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/285)

The best fix is to remove the unused symbol import from `src/easyvvuq/utils/dataset_importer.py` without changing any runtime behavior.

- **General approach:** delete imports that are never referenced.
- **Specific change:** in the import block near line 19, remove `from easyvvuq.constants import Status`.
- No additional methods, definitions, or dependencies are required.
- This preserves functionality while resolving the CodeQL warning and improving readability.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
