### PR TITLE
Potential fix for code scanning alert no. 292: Missing call to superclass `__init__` during object initialization

### DIFF
--- a/src/easyvvuq/analysis/mcmc.py
+++ b/src/easyvvuq/analysis/mcmc.py
@@ -21,6 +21,7 @@ class MCMCAnalysisResults(AnalysisResults):
     """
 
     def __init__(self, chains):
+        super().__init__()
         self.chains = chains
 
     def plot_hist(self, input_parameter, chain=None, skip=0, merge=True):


### PR DESCRIPTION
Potential fix for [https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/292](https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/292)

General fix: in subclass constructors, call the parent initializer (`super().__init__(...)`) before subclass-specific field setup, unless there is a deliberate and documented reason not to.

Best fix here (without changing functionality): update `MCMCAnalysisResults.__init__` in `src/easyvvuq/analysis/mcmc.py` to call `super().__init__()` and then keep existing `self.chains = chains`. No new imports or additional methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
