### PR TITLE
Potential fix for code scanning alert no. 291: Missing call to superclass `__init__` during object initialization

### DIFF
--- a/src/easyvvuq/analysis/gp_analyse.py
+++ b/src/easyvvuq/analysis/gp_analyse.py
@@ -41,6 +41,7 @@ class GaussianProcessSurrogateResults(AnalysisResults):
     """
 
     def __init__(self, gp, parameters, qoi):
+        super().__init__()
         self.gp = gp
         self.parameters = parameters
         self.qoi = qoi


### PR DESCRIPTION
Potential fix for [https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/291](https://github.com/UCL-CCS/EasyVVUQ/security/code-scanning/291)

General fix: in any subclass `__init__`, call the parent initializer (`super().__init__(...)`) so base-class state is initialized.

Best minimal fix here: update `GaussianProcessSurrogateResults.__init__` in `src/easyvvuq/analysis/gp_analyse.py` to invoke `super().__init__()` before assigning subclass fields. This preserves existing functionality while ensuring `AnalysisResults` initialization is not skipped. No imports or new helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
